### PR TITLE
Encode decode kafka mocked messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [9.14.12] - 2022-02-26
+
+### Fixed
+
+- Now Kafka mocked producer and consumer encodes messages using `ProducerRecord` the same way as in production
+  environment.
+
 ## [9.14.10] - 2022-02-23
 
 ### Added
@@ -207,7 +214,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v9.14.10...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v9.14.12...HEAD
+
+[9.14.12]: https://github.com/macielti/common-clj/compare/v9.14.10...v9.14.12
 
 [9.14.10]: https://github.com/macielti/common-clj/compare/v9.13.10...v9.14.10
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "9.14.10"
+(defproject net.clojars.macielti/common-clj "9.14.12"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/common_clj/component/kafka/producer.clj
+++ b/src/common_clj/component/kafka/producer.clj
@@ -16,9 +16,9 @@
       .get))
 
 (defmethod produce! :test
-  [document
+  [{:keys [topic message]}
    {:keys [produced-messages]}]
-  (swap! produced-messages conj document))
+  (swap! produced-messages conj (ProducerRecord. (name topic) (json/encode message))))
 
 (defrecord Producer [config]
   component/Lifecycle

--- a/test/integration/integration/kafka_produce_messages.clj
+++ b/test/integration/integration/kafka_produce_messages.clj
@@ -32,7 +32,7 @@
                                  producer)
 
     (testing "that we can use kafka producer to send messages"
-      (is (= [{:message {:test-title "just a simple test"}
-               :topic   :consumer-topic-test}]
+      (is (= [{:topic   :consumer-topic-test
+               :message {:test-title "just a simple test"}}]
              (component.consumer/produced-messages consumer))))
     (component/stop system)))


### PR DESCRIPTION
## [9.14.12] - 2022-02-26

### Fixed

- Now Kafka mocked producer and consumer encodes messages using `ProducerRecord` the same way as in production
  environment.

[9.14.12]: https://github.com/macielti/common-clj/compare/v9.14.10...v9.14.12