### PR TITLE
Fixed problem with `DatomicLocal` component while running integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [23.42.46] - 2023-11-12
+
+## Fixed
+
+- Fixed problem with `DatomicLocal` component while running integration tests, the database was not being cleaned after
+  each test execution.
+
 ## [23.42.45] - 2023-11-11
 
 ## Fixed
@@ -584,7 +591,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v23.42.45...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v23.42.46...HEAD
+
+[23.42.46]: https://github.com/macielti/common-clj/compare/v23.42.45...v23.42.46
 
 [23.42.45]: https://github.com/macielti/common-clj/compare/v23.42.44...v23.42.45
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "23.42.45"
+(defproject net.clojars.macielti/common-clj "23.42.46"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/common_clj/component/datomic.clj
+++ b/src/common_clj/component/datomic.clj
@@ -1,7 +1,8 @@
 (ns common-clj.component.datomic
   (:require [com.stuartsierra.component :as component]
             [datomic.api :as d]
-            [datomic.client.api :as dl]))
+            [datomic.client.api :as dl]
+            [schema.core :as s]))
 
 (defn mocked-datomic [datomic-schemas]
   (let [datomic-uri "datomic:mem://mocked"
@@ -40,8 +41,12 @@
 (defrecord DatomicLocal [config schemas]
   component/Lifecycle
   (start [component]
-    (let [storage-dir (-> config :config :datomic-local :storage-dir)
-          db-name (-> config :config :datomic-local :db-name)
+    (let [config' (:config config)
+          current-env (:current-env config')
+          storage-dir (-> (:datomic-local config') :storage-dir)
+          db-name (case current-env
+                    :prod (-> (:datomic-local config') :db-name)
+                    :test (str (random-uuid)))
           client (dl/client {:server-type :datomic-local
                              :storage-dir storage-dir
                              :system      "prod"})


### PR DESCRIPTION
## Fixed

- Fixed problem with `DatomicLocal` component while running integration tests, the database was not being cleaned after
  each test execution.