### PR TITLE
Handle telegram bot callback queries as commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -622,7 +622,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v23.45.47...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v23.46.47...HEAD
+
+[23.46.47]: https://github.com/macielti/common-clj/compare/v23.45.47...v23.46.47
 
 [23.45.47]: https://github.com/macielti/common-clj/compare/v23.45.46...v23.45.47
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [23.46.47] - 2023-11-24
+
+## Added
+
+- Add handler for Telegram bot callback queries. Now the data from the callback query is treated as a bot command.
+
 ## [23.45.47] - 2023-11-20
 
 ## Fixed

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "23.45.47"
+(defproject net.clojars.macielti/common-clj "23.46.47"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/common_clj/component/telegram/adapters/update.clj
+++ b/src/common_clj/component/telegram/adapters/update.clj
@@ -17,7 +17,8 @@
   (cond
     (or (= (-> update :message :entities first :type) "bot_command")
         (= (-> update :message :caption_entities first :type) "bot_command")
-        (= (-> update :channel_post :entities first :type) "bot_command")) :bot-command
+        (= (-> update :channel_post :entities first :type) "bot_command")
+        (:callback_query update)) :bot-command
     :else :others))
 
 (s/defn update->chat-id :- s/Int
@@ -32,7 +33,8 @@
   [update]
   (or (-> update :message :caption)
       (-> update :message :text)
-      (-> update :channel_post :text)))
+      (-> update :channel_post :text)
+      (-> update :callback_query :data)))
 
 (s/defn wire->internal :- component.telegram.models.update/Update
   [{:keys [update_id] :as update}]


### PR DESCRIPTION
## Added

- Add handler for Telegram bot callback queries. Now the data from the callback query is treated as a bot command.