### PR TITLE
Refactors to `TelegramConsumer` in order to define command interceptors in a way that allows a more reusable and extendable code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [24.46.47] - 2023-11-25
+
+### Changed
+
+- Refactors to `TelegramConsumer` in order to define command interceptors in a way that allows a more reusable and
+  extendable code.
+
 ## [23.46.47] - 2023-11-24
 
 ## Added
@@ -622,7 +629,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v23.46.47...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v24.46.47...HEAD
+
+[24.46.47]: https://github.com/macielti/common-clj/compare/v23.46.47...v24.46.47
 
 [23.46.47]: https://github.com/macielti/common-clj/compare/v23.45.47...v23.46.47
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "23.46.47"
+(defproject net.clojars.macielti/common-clj "24.46.47"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/common_clj/component/telegram/consumer.clj
+++ b/src/common_clj/component/telegram/consumer.clj
@@ -41,14 +41,14 @@
    consumers :- component.telegram.models.consumer/Consumers
    {:keys [telegram-consumer config] :as components}]
   (let [{:update/keys [chat-id id type] :as update'} (telegram.adapters.message/wire->internal update)
-        {:keys [handler error-handler] :as consumer} (telegram.adapters.message/update->consumer update' consumers)
+        {:keys [handler interceptors error-handler] :as consumer} (telegram.adapters.message/update->consumer update' consumers)
         token (-> config :telegram :token)
         context {:update     update'
                  :components components}]
     (when (and handler update' id)
       (try
         (chain/execute context
-                       (concat (interceptors-by-consumer consumer consumers)
+                       (concat interceptors
                                [(interceptor/interceptor {:name  :handler-interceptor
                                                           :enter handler})]))
         (catch Exception e
@@ -69,13 +69,13 @@
    consumers :- component.telegram.models.consumer/Consumers
    {:keys [telegram-consumer] :as components}]
   (let [update' (telegram.adapters.message/wire->internal update)
-        {:keys [handler] :as consumer} (telegram.adapters.message/update->consumer update' consumers)
+        {:keys [handler interceptors] :as consumer} (telegram.adapters.message/update->consumer update' consumers)
         context {:update     update'
                  :components components}]
     (when (and handler update)
       (try
         (chain/execute context
-                       (concat (interceptors-by-consumer consumer consumers)
+                       (concat interceptors
                                [(interceptor/interceptor {:name  :handler-interceptor
                                                           :enter handler})]))))
     (when (:consumed-updates telegram-consumer)

--- a/src/common_clj/component/telegram/models/consumer.clj
+++ b/src/common_clj/component/telegram/models/consumer.clj
@@ -3,10 +3,9 @@
   (:import (clojure.lang IFn)))
 
 (s/defschema Consumer
-  {(s/optional-key :interceptors)  [s/Keyword]
+  {(s/optional-key :interceptors)  [s/Any]
    :handler                        IFn
    (s/optional-key :error-handler) IFn})
 
 (s/defschema Consumers
-  {(s/optional-key :interceptors) [s/Any]
-   (s/optional-key :bot-command)  {s/Keyword Consumer}})
+  {(s/optional-key :bot-command) {s/Keyword Consumer}})

--- a/test/integration/integration/telegram_consumer_component_test.clj
+++ b/test/integration/integration/telegram_consumer_component_test.clj
@@ -20,9 +20,8 @@
   (reset! test-state update))
 
 (def consumers
-  {:interceptors [test-interceptor]
-   :bot-command  {:test {:interceptors [:test-interceptor]
-                         :handler      test-consumer!}}})
+  {:bot-command {:test {:interceptors [test-interceptor]
+                        :handler      test-consumer!}}})
 
 (def system-test
   (component/system-map


### PR DESCRIPTION
### Changed

- Refactors to `TelegramConsumer` in order to define command interceptors in a way that allows a more reusable and
  extendable code.