### PR TITLE
Added log to show the result of datomic database creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [28.56.57] - 2024-08-25
+
+## Added
+
+- Added log to show the result of datomic database creation.
+
 ## [28.56.56] - 2024-08-22
 
 ## Added
@@ -774,7 +780,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v28.56.56...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v28.56.57...HEAD
+
+[28.56.56]: https://github.com/macielti/common-clj/compare/v28.56.56...v28.56.57
 
 [28.56.56]: https://github.com/macielti/common-clj/compare/v28.56.55...v28.56.56
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "28.56.56"
+(defproject net.clojars.macielti/common-clj "28.56.57"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/common_clj/component/datomic.clj
+++ b/src/common_clj/component/datomic.clj
@@ -1,7 +1,8 @@
 (ns common-clj.component.datomic
   (:require [com.stuartsierra.component :as component]
             [datomic.api :as d]
-            [datomic.client.api :as dl]))
+            [datomic.client.api :as dl]
+            [taoensso.timbre :as log]))
 
 (defn mocked-datomic [datomic-schemas]
   (let [datomic-uri "datomic:mem://unit-tests"
@@ -15,7 +16,7 @@
   (start [component]
     (let [datomic-uri (or (-> config :config :datomic-uri)
                           "datomic:mem://integration-tests")
-          connection (do (d/create-database datomic-uri)
+          connection (do (log/info ::database-creation (d/create-database datomic-uri))
                          (d/connect datomic-uri))]
       @(d/transact connection (flatten schemas))
       (assoc component :datomic connection)))


### PR DESCRIPTION
This pull request includes several updates to the `common-clj` project, focusing on version updates, logging enhancements, and documentation improvements. The most important changes include updating the project version, adding logging for database creation, and updating the changelog to reflect these changes.

### Version and Documentation Updates:
* [`project.clj`](diffhunk://#diff-274071745a4e2a04b647d79d500537e6dc13eee54f44d0426140026293701d1bL1-R1): Updated the project version from `28.56.56` to `28.56.57`.

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13): Added a new version entry for `28.56.57` and updated the comparison links to reflect the new version. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL777-R785)

### Logging Enhancements:
* `src/common_clj/component/datomic.clj`: 
  - Added `taoensso.timbre` as a logging library.
  - Added a log statement to show the result of the Datomic database creation.