### PR TITLE
Fixed bug in the Cronjob component (Integrant)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [29.58.59] - 2024-09-05
+
+### Fixed
+
+- Fix bug on `Cronjob component (Integrant)`. The component wasn't able to access the defined tasks properly.
+
 ## [29.58.58] - 2024-09-05
 
 ### Added
@@ -833,7 +839,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v29.58.58...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v29.58.59...HEAD
+
+[29.58.59]: https://github.com/macielti/common-clj/compare/v29.58.58...v29.58.59
 
 [29.58.58]: https://github.com/macielti/common-clj/compare/v29.58.57...v29.58.58
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "29.58.58"
+(defproject net.clojars.macielti/common-clj "29.58.59"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/common_clj/integrant_components/cronjob.clj
+++ b/src/common_clj/integrant_components/cronjob.clj
@@ -11,7 +11,7 @@
 (defmethod ig/init-key ::cronjob
   [_ {:keys [tasks components]}]
   (log/info :starting ::cronjob)
-  (let [tasks' (tasks-with-components (:tasks tasks) components)
+  (let [tasks' (tasks-with-components tasks components)
         scheduler (io.scheduler/scheduler tasks' {} {:clock {:timezone "UTC"}})]
 
     (io.scheduler/start! scheduler)


### PR DESCRIPTION
### Fixed

- Fix bug on `Cronjob component (Integrant)`. The component wasn't able to access the defined tasks properly.