### PR TITLE
Fix bug on `AWS SQS Producer component (Integrant)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- Fix bug on `AWS SQS Consumer component (Integrant)`. The component wasn't sending the messages passing the right
+- Fix bug on `AWS SQS Producer component (Integrant)`. The component wasn't sending the messages passing the right
   params.
 
 ## [29.58.59] - 2024-09-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [29.58.60] - 2024-09-06
+
+### Fixed
+
+- Fix bug on `AWS SQS Consumer component (Integrant)`. The component wasn't sending the messages passing the right
+  params.
+
 ## [29.58.59] - 2024-09-05
 
 ### Fixed
@@ -839,7 +846,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v29.58.59...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v29.58.60...HEAD
+
+[29.58.60]: https://github.com/macielti/common-clj/compare/v29.58.59...v29.58.60
 
 [29.58.59]: https://github.com/macielti/common-clj/compare/v29.58.58...v29.58.59
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "29.58.59"
+(defproject net.clojars.macielti/common-clj "29.58.60"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/common_clj/integrant_components/sqs_producer.clj
+++ b/src/common_clj/integrant_components/sqs_producer.clj
@@ -14,9 +14,8 @@
   [{:keys [queue payload]}
    {:keys [aws-credentials]}]
   (let [payload' (assoc payload :meta {:correlation-id (-> (common-traceability/current-correlation-id)
-                                                           common-traceability/correlation-id-appended)})
-        queue-url (-> (sqs/get-queue-url aws-credentials queue) :queue-url)]
-    (sqs/send-message aws-credentials {:queue-url    queue-url
+                                                           common-traceability/correlation-id-appended)})]
+    (sqs/send-message aws-credentials {:queue-url    (-> (sqs/get-queue-url aws-credentials queue) :queue-url)
                                        :message-body (prn-str payload')})))
 
 (s/defmethod produce! :test

--- a/src/common_clj/integrant_components/sqs_producer.clj
+++ b/src/common_clj/integrant_components/sqs_producer.clj
@@ -14,10 +14,10 @@
   [{:keys [queue payload]}
    {:keys [aws-credentials]}]
   (let [payload' (assoc payload :meta {:correlation-id (-> (common-traceability/current-correlation-id)
-                                                           common-traceability/correlation-id-appended)})]
-    (sqs/send-message aws-credentials
-                      (sqs/get-queue-url aws-credentials queue)
-                      (prn-str payload'))))
+                                                           common-traceability/correlation-id-appended)})
+        queue-url (-> (sqs/get-queue-url aws-credentials queue) :queue-url)]
+    (sqs/send-message aws-credentials {:queue-url    queue-url
+                                       :message-body (prn-str payload')})))
 
 (s/defmethod produce! :test
   [{:keys [queue payload]}


### PR DESCRIPTION
### Fixed

- Fix bug on `AWS SQS Producer component (Integrant)`. The component wasn't sending the messages passing the right
  params.
