### PR TITLE
Minor improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Improvements on `common-clj.integrant-components.datomic/mocked-datomic` to avoid point to the same in-memory database
+  path between tests.
+
+### Added
+
+- Added `common-clj.integrant-components.datomic/transact-and-lookup-entity!` function to make easier to transact and
+  lookup entities in the database.
+
 ## [29.58.61] - 2024-09-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [29.59.61] - 2024-09-07
+
 ### Fixed
 
 - Improvements on `common-clj.integrant-components.datomic/mocked-datomic` to avoid point to the same in-memory database
@@ -14,6 +16,8 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Added `common-clj.integrant-components.datomic/transact-and-lookup-entity!` function to make easier to transact and
   lookup entities in the database.
+- Added full automatic test (unit) coverage for `common-clj.integrant-components.datomic` namespace.
+- Added full automatic test (unit, integration) coverage for `common-clj.integrant-components.routes` namespace.
 
 ## [29.58.61] - 2024-09-06
 
@@ -862,9 +866,11 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v29.58.61...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v29.59.61...HEAD
 
-[29.58.60]: https://github.com/macielti/common-clj/compare/v29.58.60...v29.58.61
+[29.59.61]: https://github.com/macielti/common-clj/compare/v29.58.61...v29.59.61
+
+[29.58.61]: https://github.com/macielti/common-clj/compare/v29.58.60...v29.58.61
 
 [29.58.60]: https://github.com/macielti/common-clj/compare/v29.58.59...v29.58.60
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "29.58.61"
+(defproject net.clojars.macielti/common-clj "29.59.61"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/test/unit/common_clj/integrant_components/config_test.clj
+++ b/test/unit/common_clj/integrant_components/config_test.clj
@@ -1,0 +1,24 @@
+(ns common-clj.integrant-components.config-test
+  (:require [clojure.test :refer :all]
+            [common-clj.integrant-components.config :as component.config]
+            [schema.test :as s]))
+
+(s/deftest config-file-test
+  (testing "That we can read a config file"
+    (is (= {:prod {:bootstrap-server       "http://localhost:9092"
+                   :service-authentication {:auth-server-base-url "https://example.com"
+                                            :password             "random-password"
+                                            :username             "service-name"}}
+            :test {:bootstrap-server                              "http://localhost:9092"
+                   :dead-letter-queue-service-integration-enabled true
+                   :new-relic-api-key                             "random-api-key"
+                   :postgresql-uri                                "jdbc:postgres://localhost:5432/postgres?user=postgres&password=postgres"
+                   :rabbitmq-uri                                  "amqp://guest:guest@localhost:5672"
+                   :service                                       {:host "0.0.0.0"
+                                                                   :port 8000}
+                   :service-authentication                        {:auth-server-base-url "https://example.com"
+                                                                   :password             "random-password"
+                                                                   :username             "service-name"}
+                   :service-name                                  "test-service-name"
+                   :topics                                        ["test.example"]}}
+           (component.config/config-file! "resources/config_test.edn")))))

--- a/test/unit/common_clj/integrant_components/routes_test.clj
+++ b/test/unit/common_clj/integrant_components/routes_test.clj
@@ -1,6 +1,5 @@
-(ns integration.integrant-components.routes-component-test
+(ns common-clj.integrant-components.routes-test
   (:require [clojure.test :refer :all]
-            [common-clj.integrant-components.routes]
             [integrant.core :as ig]
             [matcher-combinators.test :refer [match?]]
             [schema.test :as s]))
@@ -13,12 +12,11 @@
 (def config
   {:common-clj.integrant-components.routes/routes {:routes routes}})
 
-(s/deftest service-component-test
-  (testing "That we can define endpoints"
+(s/deftest routes-component-definition-test
+  (testing "That we can define route component and start it"
     (let [system (ig/init config)]
-      (is (match? #{["/hello-world"
-                     :get function?
-                     :route-name
-                     :fetch-hello-world]}
-                  (:common-clj.integrant-components.routes/routes system)))
-      (ig/halt! system))))
+      (is (match? {:common-clj.integrant-components.routes/routes #{["/hello-world"
+                                                                     :get function?
+                                                                     :route-name :fetch-hello-world]}}
+                  system))
+      (is (nil? (ig/halt! system))))))


### PR DESCRIPTION
### Fixed

- Improvements on `common-clj.integrant-components.datomic/mocked-datomic` to avoid point to the same in-memory database
  path between tests.

### Added

- Added `common-clj.integrant-components.datomic/transact-and-lookup-entity!` function to make easier to transact and
  lookup entities in the database.
- Added full automatic test (unit) coverage for `common-clj.integrant-components.datomic` namespace.
- Added full automatic test (unit, integration) coverage for `common-clj.integrant-components.routes` namespace.