### PR TITLE
Add AWS Auth (Integrant) component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [29.60.61] - 2024-09-09
+
+### Added
+
+- Added AWS Auth (Integrant) component to define aws credentials globally.
+
+### Changed
+
+- AWS SQS Consumer component (Integrant) and AWS SQS Producer component (Integrant) now use the globally defined aws
+  credentials from AWS Auth (Integrant) component.
+
 ## [29.59.61] - 2024-09-07
 
 ### Fixed
@@ -866,7 +877,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v29.59.61...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v29.60.61...HEAD
+
+[29.60.61]: https://github.com/macielti/common-clj/compare/v29.59.61...v29.60.61
 
 [29.59.61]: https://github.com/macielti/common-clj/compare/v29.58.61...v29.59.61
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "29.59.61"
+(defproject net.clojars.macielti/common-clj "29.60.61"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -4,13 +4,9 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url  "https://www.eclipse.org/legal/epl-2.0/"}
 
-  :plugins [[lein-codox "0.10.8"]
-            [lein-cloverage "1.2.4"]
+  :plugins [[lein-cloverage "1.2.4"]
             [com.github.clojure-lsp/lein-clojure-lsp "1.4.9"]
             [com.github.liquidz/antq "RELEASE"]]
-
-  :codox {:metadata    {:doc "Just common Clojure code that I use across projects."}
-          :output-path "docs"}
 
   :exclusions [log4j]
 

--- a/src/common_clj/integrant_components/aws_auth.clj
+++ b/src/common_clj/integrant_components/aws_auth.clj
@@ -1,0 +1,15 @@
+(ns common-clj.integrant-components.aws-auth
+  (:require [amazonica.core :as aws]
+            [integrant.core :as ig]
+            [io.pedestal.log :as log]))
+
+(defmethod ig/init-key ::aws-auth
+  [_ {:keys [components]}]
+  (log/info :starting ::aws-auth)
+  (aws/defcredential (-> components :config :aws-credentials :access-key)
+    (-> components :config :aws-credentials :secret-key)
+    (-> components :config :aws-credentials :endpoint)))
+
+(defmethod ig/halt-key! ::aws-auth
+  [_ _aws-auth]
+  (log/info :stopping ::aws-auth))

--- a/src/common_clj/integrant_components/sqs_producer.clj
+++ b/src/common_clj/integrant_components/sqs_producer.clj
@@ -11,12 +11,10 @@
     current-env))
 
 (s/defmethod produce! :prod
-  [{:keys [queue payload]}
-   {:keys [aws-credentials]}]
+  [{:keys [queue payload]} _producer]
   (let [payload' (assoc payload :meta {:correlation-id (-> (common-traceability/current-correlation-id)
                                                            common-traceability/correlation-id-appended)})]
-    (sqs/send-message aws-credentials {:queue-url    (-> (sqs/get-queue-url aws-credentials queue) :queue-url)
-                                       :message-body (prn-str payload')})))
+    (sqs/send-message (sqs/get-queue-url queue) (prn-str payload'))))
 
 (s/defmethod produce! :test
   [{:keys [queue payload]}
@@ -29,20 +27,16 @@
 (defmethod ig/init-key ::sqs-producer
   [_ {:keys [components]}]
   (log/info :starting ::sqs-producer)
-  (let [aws-credentials {:access-key (-> components :config :aws-credentials :access-key)
-                         :secret-key (-> components :config :aws-credentials :secret-key)
-                         :endpoint   (-> components :config :aws-credentials :endpoint)}]
 
-    (when (= (-> components :config :current-env) :prod)
-      (try (sqs/list-queues aws-credentials)
-           (catch Exception ex
-             (log/error :invalid-credentials :exception ex)
-             (throw ex))))
+  (when (= (-> components :config :current-env) :prod)
+    (try (sqs/list-queues)
+         (catch Exception ex
+           (log/error :invalid-credentials :exception ex)
+           (throw ex))))
 
-    (medley/assoc-some {:current-env     (-> components :config :current-env)
-                        :aws-credentials aws-credentials}
-                       :produced-messages (when (= (-> components :config :current-env) :test)
-                                            (atom [])))))
+  (medley/assoc-some {:current-env (-> components :config :current-env)}
+                     :produced-messages (when (= (-> components :config :current-env) :test)
+                                          (atom []))))
 
 (defmethod ig/halt-key! ::sqs-producer
   [_ _sqs-producer]


### PR DESCRIPTION
### Added

- Added AWS Auth (Integrant) component to define aws credentials globally.

### Changed

- AWS SQS Consumer component (Integrant) and AWS SQS Producer component (Integrant) now use the globally defined aws
  credentials from AWS Auth (Integrant) component.