### PR TITLE
Implement retry policy for Datomic (Integrant) component start process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [29.61.61] - 2024-09-11
+
+### Added
+
+- Retry policy for Datomic (Integrant) component to make it more resilient to database connection problems while staring
+  the component.
+
 ## [29.60.61] - 2024-09-09
 
 ### Added
@@ -877,7 +884,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v29.60.61...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v29.61.61...HEAD
+
+[29.61.61]: https://github.com/macielti/common-clj/compare/v29.60.61...v29.61.61
 
 [29.60.61]: https://github.com/macielti/common-clj/compare/v29.59.61...v29.60.61
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "29.60.61"
+(defproject net.clojars.macielti/common-clj "29.61.61"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
@@ -55,7 +55,8 @@
                  [amazonica "0.3.167"]
                  [com.fasterxml.jackson.core/jackson-core "2.18.0-rc1"]
                  [com.fasterxml.jackson.core/jackson-databind "2.18.0-rc1"]
-                 [com.fasterxml.jackson.core/jackson-annotations "2.18.0-rc1"]]
+                 [com.fasterxml.jackson.core/jackson-annotations "2.18.0-rc1"]
+                 [diehard "0.11.12"]]
 
   :injections [(require 'hashp.core)]
 

--- a/src/common_clj/integrant_components/datomic.clj
+++ b/src/common_clj/integrant_components/datomic.clj
@@ -37,7 +37,7 @@
                         (str "datomic:mem://" (random-uuid)))
         connection (dh/with-retry {:retry-on    ActiveMQNotConnectedException
                                    :max-retries 3}
-                     (log/info ::database-creation (d/create-database datomic-uri))
+                     (log/info ::database-created? (d/create-database datomic-uri))
                      (d/connect datomic-uri))]
     @(d/transact connection (flatten schemas))
     connection))


### PR DESCRIPTION
### Added

- Retry policy for Datomic (Integrant) component to make it more resilient to database connection problems while staring
  the component.