### PR TITLE
Fix bug on `AWS SQS Producer component (Integrant)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [29.61.63] - 2024-09-13
+
+### Fixed
+
+- Fix bug on `AWS SQS Producer component (Integrant)`. The component wasn't sending the params for the message produce
+  operation properly.
+- Removed calls to `#p`. This should be used only on debugging process.
+
+### Added
+
+- Try to create AWS SQS queues while starting `AWS SQS Producer component (Integrant)`.
+
 ## [29.61.62] - 2024-09-11
 
 ### Changed
@@ -890,7 +902,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v29.61.61...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v29.61.63...HEAD
+
+[29.61.63]: https://github.com/macielti/common-clj/compare/v29.61.62...v29.61.63
 
 [29.61.62]: https://github.com/macielti/common-clj/compare/v29.61.61...v29.61.62
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "29.61.62"
+(defproject net.clojars.macielti/common-clj "29.61.63"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/common_clj/integrant_components/sqs_consumer.clj
+++ b/src/common_clj/integrant_components/sqs_consumer.clj
@@ -49,13 +49,13 @@
                 (try
                   (let [{:keys [handler-fn schema]} (get consumers queue)
                         message' (-> message :body edn/read-string)]
-                    (binding [common-traceability/*correlation-id* #p (-> #p message'
-                                                                          :meta
-                                                                          :correlation-id
-                                                                          common-traceability/correlation-id-appended)]
+                    (binding [common-traceability/*correlation-id* (-> message'
+                                                                       :meta
+                                                                       :correlation-id
+                                                                       common-traceability/correlation-id-appended)]
                       (try
-                        (handler-fn #p {:message    (s/validate schema (dissoc message' :meta))
-                                        :components components})
+                        (handler-fn {:message    (s/validate schema (dissoc message' :meta))
+                                     :components components})
                         (log/info :message-handled {:queue   queue
                                                     :message (dissoc message :body)})
                         (sqs/delete-message (assoc message :queue-url queue-url))


### PR DESCRIPTION
### Fixed

- Fix bug on `AWS SQS Producer component (Integrant)`. The component wasn't sending the params for the message produce
  operation properly.
- Removed calls to `#p`. This should be used only on debugging process.

### Added

- Try to create AWS SQS queues while starting `AWS SQS Producer component (Integrant)`.