### PR TITLE
Fix expected input schema for `common-clj.integrant-components.sqs-consumer/create-sqs-queues!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [29.61.64] - 2024-09-13
+
+### Fixed
+
+- Fixed expected schema param type for `queues` on `common-clj.integrant-components.sqs-consumer/create-sqs-queues!`.
+
 ## [29.61.63] - 2024-09-13
 
 ### Fixed
@@ -902,7 +908,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v29.61.63...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v29.61.64...HEAD
+
+[29.61.64]: https://github.com/macielti/common-clj/compare/v29.61.63...v29.61.64
 
 [29.61.63]: https://github.com/macielti/common-clj/compare/v29.61.62...v29.61.63
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "29.61.63"
+(defproject net.clojars.macielti/common-clj "29.61.64"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/common_clj/integrant_components/sqs_consumer.clj
+++ b/src/common_clj/integrant_components/sqs_consumer.clj
@@ -26,7 +26,7 @@
       (clojure.set/difference (set @consumed-messages))))
 
 (s/defn create-sqs-queues!
-  [queues :- s/Str]
+  [queues :- [s/Str]]
   (doseq [queue queues]
     (sqs/create-queue :queue-name queue)))
 


### PR DESCRIPTION
### Fixed

- Fixed expected schema param type for `queues` on `common-clj.integrant-components.sqs-consumer/create-sqs-queues!`.