### PR TITLE
Instead of logging (at INFO level) each message consumed by `AWS SQS Consumer component (Integrant)`, now we are   logging that info at DEBUG level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [29.61.66] - 2024-09-13
+
+### Changed
+
+- Instead of logging (at INFO level) each message consumed by `AWS SQS Consumer component (Integrant)`, now we are
+  logging that info at DEBUG level.
+
 ## [29.61.65] - 2024-09-13
 
 ### Fixed
@@ -915,7 +922,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v29.61.65...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v29.61.66...HEAD
+
+[29.61.66]: https://github.com/macielti/common-clj/compare/v29.61.65...v29.61.66
 
 [29.61.65]: https://github.com/macielti/common-clj/compare/v29.61.64...v29.61.65
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "29.61.65"
+(defproject net.clojars.macielti/common-clj "29.61.66"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/common_clj/integrant_components/sqs_consumer.clj
+++ b/src/common_clj/integrant_components/sqs_consumer.clj
@@ -56,8 +56,8 @@
                       (try
                         (handler-fn {:message    (s/validate schema (dissoc message' :meta))
                                      :components components})
-                        (log/info :message-handled {:queue   queue
-                                                    :message (dissoc message :body)})
+                        (log/debug ::message-handled {:queue   queue
+                                                      :message (dissoc message :body)})
                         (sqs/delete-message (assoc message :queue-url queue-url))
                         (catch Exception ex-handling-message
                           (log/error ::exception-while-handling-aws-sqs-message ex-handling-message)))))
@@ -87,7 +87,7 @@
                     (handler-fn {:message    (-> message :payload (dissoc message :meta))
                                  :components components})
 
-                    (log/info :message-handled message)
+                    (log/debug ::message-handled message)
 
                     (commit-message-as-consumed! message consumed-messages))
                   (catch Exception ex


### PR DESCRIPTION
### Changed

- Instead of logging (at INFO level) each message consumed by `AWS SQS Consumer component (Integrant)`, now we are
  logging that info at DEBUG level.