### PR TITLE
Now the AWS SQS Consumer component (Integrant) is able to consume messages applying some level of parallelism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [29.62.66] - 2024-09-14
+
+### Added
+
+- Now the AWS SQS Consumer component (Integrant) is able to consume messages applying some level of parallelism.
+
 ## [29.61.66] - 2024-09-13
 
 ### Changed
@@ -922,7 +928,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v29.61.66...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v29.62.66...HEAD
+
+[29.62.66]: https://github.com/macielti/common-clj/compare/v29.61.66...v29.62.66
 
 [29.61.66]: https://github.com/macielti/common-clj/compare/v29.61.65...v29.61.66
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "29.61.66"
+(defproject net.clojars.macielti/common-clj "29.62.66"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
@@ -56,7 +56,8 @@
                  [com.fasterxml.jackson.core/jackson-core "2.18.0-rc1"]
                  [com.fasterxml.jackson.core/jackson-databind "2.18.0-rc1"]
                  [com.fasterxml.jackson.core/jackson-annotations "2.18.0-rc1"]
-                 [diehard "0.11.12"]]
+                 [diehard "0.11.12"]
+                 [parallel "0.10"]]
 
   :injections [(require 'hashp.core)]
 


### PR DESCRIPTION
### Added

- Now the AWS SQS Consumer component (Integrant) is able to consume messages applying some level of parallelism.