### PR TITLE
Control the timeout in ms for the `AWS SQS Consumer` component (Integrant) while handling each message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [29.63.69] - 2024-09-15
+
+### Added
+
+- Now you can control the timeout in ms for the `AWS SQS Consumer` component (Integrant) while handling each message.
+
 ## [29.62.69] - 2024-09-14
 
 ### Changed
@@ -946,7 +952,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v29.62.69...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v29.63.69...HEAD
+
+[29.63.69]: https://github.com/macielti/common-clj/compare/v29.62.69...v29.63.69
 
 [29.62.69]: https://github.com/macielti/common-clj/compare/v29.62.68...v29.62.69
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "29.62.69"
+(defproject net.clojars.macielti/common-clj "29.63.69"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"


### PR DESCRIPTION
### Added

- Now you can control the timeout in ms for the `AWS SQS Consumer` component (Integrant) while handling each message.