### PR TITLE
Add tests for Prometheus (Integrant) component

### DIFF
--- a/test/integration/integration/integrant_components/prometheus_component_test.clj
+++ b/test/integration/integration/integrant_components/prometheus_component_test.clj
@@ -1,0 +1,54 @@
+(ns integration.integrant-components.prometheus-component-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
+            [common-clj.integrant-components.prometheus :as component.prometheus]
+            [common-clj.integrant-components.routes]
+            [common-clj.integrant-components.service]
+            [iapetos.core :as prometheus]
+            [integrant.core :as ig]
+            [io.pedestal.test :as test]
+            [matcher-combinators.test :refer [match?]]
+            [schema.test :as s]))
+
+(def routes [["/metrics" :get [component.prometheus/expose-metrics-http-request-handler]
+              :route-name :fetch-metrics]])
+
+(def config
+  {:common-clj.integrant-components.prometheus/prometheus {:metrics [(prometheus/counter :example/metric)]}
+   :common-clj.integrant-components.routes/routes         {:routes routes}
+   :common-clj.integrant-components.service/service       {:components {:config     {:service          {:host "0.0.0.0"
+                                                                                                        :port 8080}
+                                                                                     :prometheus-token "test-token"}
+                                                                        :prometheus (ig/ref :common-clj.integrant-components.prometheus/prometheus)
+                                                                        :routes     (ig/ref :common-clj.integrant-components.routes/routes)}}})
+
+(s/deftest prometheus-component-test
+  (let [system (ig/init config)
+        service-fn (-> system :common-clj.integrant-components.service/service :io.pedestal.http/service-fn)
+        prometheus (:common-clj.integrant-components.prometheus/prometheus system)]
+
+    (testing "That we can fetch metrics"
+      (is (match? {:status 200
+                   :body   #(str/includes? % "HELP example_metric_total a counter metric.")}
+                  (test/response-for service-fn :get "/metrics" :headers {"authorization" "Bearer test-token"}))))
+
+    (testing "That we can't fetch metrics without authorization"
+      (is (match? {:status 403
+                   :body   "Not Authorized"}
+                  (test/response-for service-fn :get "/metrics" :headers {"authorization" "Bearer wrong-token"}))))
+
+    (testing "That we can produce metric count incrementation"
+
+      (prometheus/inc (:registry prometheus) :example/metric)
+
+      (is (match? {:status 200
+                   :body   #(str/includes? % "example_metric_total 1")}
+                  (test/response-for service-fn :get "/metrics" :headers {"authorization" "Bearer test-token"})))
+
+      (prometheus/inc (:registry prometheus) :example/metric)
+
+      (is (match? {:status 200
+                   :body   #(str/includes? % "example_metric_total 2")}
+                  (test/response-for service-fn :get "/metrics" :headers {"authorization" "Bearer test-token"}))))
+
+    (ig/halt! system)))

--- a/test/unit/common_clj/integrant_components/prometheus_test.clj
+++ b/test/unit/common_clj/integrant_components/prometheus_test.clj
@@ -1,0 +1,20 @@
+(ns common-clj.integrant-components.prometheus_test
+  (:require [clojure.test :refer :all]
+            [common-clj.integrant-components.prometheus]
+            [iapetos.core :as prometheus]
+            [integrant.core :as ig]
+            [matcher-combinators.test :refer [match?]]
+            [schema.test :as s])
+  (:import (iapetos.registry IapetosRegistry)
+           (io.prometheus.client Counter$Child)))
+
+(def config {:common-clj.integrant-components.prometheus/prometheus {:metrics [(prometheus/counter :example/metric)]}})
+
+(s/deftest prometheus-component-test
+  (testing "That we can define prometheus component and start it"
+    (let [system (ig/init config)]
+      (is (match? {:common-clj.integrant-components.prometheus/prometheus {:registry #(= (type %) IapetosRegistry)}}
+                  system))
+
+      (is (match? #(= (type %) Counter$Child)
+                  (-> system :common-clj.integrant-components.prometheus/prometheus :registry :example/metric))))))


### PR DESCRIPTION
This pull request adds integration and unit tests for the Prometheus component, ensuring proper functionality and authorization handling. The most important changes include the addition of new test namespaces, configuration definitions, and multiple test cases.

### Integration Tests

* Added a new namespace `integration.integrant-components.prometheus-component-test` to test the Prometheus component.
* Defined routes and configuration for the Prometheus component, including a service with authorization.
* Added tests to verify metrics fetching and authorization handling:
  * Fetching metrics with correct authorization.
  * Blocking metrics fetching without proper authorization.
  * Incrementing and verifying metric counts.

### Unit Tests

* Added a new namespace `common-clj.integrant-components.prometheus_test` for unit testing the Prometheus component.
* Defined configuration for the Prometheus component.
* Added tests to ensure the Prometheus component can be defined and started correctly:
  * Verifying the type of the Prometheus registry.
  * Checking the type of the metric within the registry.