### PR TITLE
Control the number of parallel consumer threads for each `AWS SQS Consumer` queue (Integrant)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [30.63.69] - 2024-09-20
+
+### Changed
+
+- Now you can control the number of parallel consumer threads for each queue on `AWS SQS Consumer` component
+  (Integrant).
+
 ## [29.63.69] - 2024-09-15
 
 ### Added
@@ -952,7 +959,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v29.63.69...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v30.63.69...HEAD
+
+[30.63.69]: https://github.com/macielti/common-clj/compare/v29.63.69...v30.63.69
 
 [29.63.69]: https://github.com/macielti/common-clj/compare/v29.62.69...v29.63.69
 

--- a/project.clj
+++ b/project.clj
@@ -56,7 +56,8 @@
                  [com.fasterxml.jackson.core/jackson-core "2.18.0-rc1"]
                  [com.fasterxml.jackson.core/jackson-databind "2.18.0-rc1"]
                  [com.fasterxml.jackson.core/jackson-annotations "2.18.0-rc1"]
-                 [diehard "0.11.12"]]
+                 [diehard "0.11.12"]
+                 [overtone/at-at "1.3.58"]]
 
   :injections [(require 'hashp.core)]
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "29.63.69"
+(defproject net.clojars.macielti/common-clj "30.63.69"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/common_clj/integrant_components/sqs_consumer.clj
+++ b/src/common_clj/integrant_components/sqs_consumer.clj
@@ -6,7 +6,8 @@
             [integrant.core :as ig]
             [medley.core :as medley]
             [schema.core :as s]
-            [taoensso.timbre :as log])
+            [taoensso.timbre :as log]
+            [overtone.at-at :as at-at])
   (:import (clojure.lang IFn)))
 
 (s/defschema Consumers
@@ -36,82 +37,107 @@
     current-env))
 
 (s/defmethod consume! :prod
-  [{:keys [switch components consumers]}]
-  (create-sqs-queues! (-> components :config :queues))
-  (let [queues (mapv (fn [queue]
-                       (-> (sqs/get-queue-url queue)
-                           (assoc :queue queue))) (-> components :config :queues))]
-    (doseq [{:keys [queue-url queue]} queues]
-      (future
-        (try
-          (while @switch
-            (let [{:keys [messages]} (sqs/receive-message :queue-url queue-url :wait-time-seconds 20)]
-              (doseq [message messages]
-                (try
-                  (let [{:keys [handler-fn schema]} (get consumers queue)
-                        message' (-> message :body edn/read-string)]
-                    (binding [common-traceability/*correlation-id* (-> message'
-                                                                       :meta
-                                                                       :correlation-id
-                                                                       common-traceability/correlation-id-appended)]
-                      (try
-                        (dh/with-timeout {:timeout-ms (get-in components [:config :message-consumption-timeout-ms] 30000)
-                                          :interrupt? true}
-                          (handler-fn {:message    (s/validate schema (dissoc message' :meta))
-                                       :components components}))
-                        (log/debug ::message-handled {:queue   queue
-                                                      :message (dissoc message :body)})
-                        (sqs/delete-message (assoc message :queue-url queue-url))
-                        (catch Exception ex-handling-message
-                          (log/error ::exception-while-handling-aws-sqs-message ex-handling-message)))))
-                  (catch Exception ex-in
-                    (log/error ex-in))))))
-          (catch Exception ex-ext
-            (log/error ex-ext)))))))
+  [{:keys [switch components queue consumer]}]
+  (let [queue-url (-> (sqs/get-queue-url queue) :queue-url)]
+    (try
+      (while @switch
+        (let [{:keys [messages]} (sqs/receive-message :queue-url queue-url :wait-time-seconds 20)]
+          (doseq [message messages]
+            (try
+              (let [message' (-> message :body edn/read-string)]
+                (binding [common-traceability/*correlation-id* (-> message'
+                                                                   :meta
+                                                                   :correlation-id
+                                                                   common-traceability/correlation-id-appended)]
+                  (try
+                    (dh/with-timeout {:timeout-ms (get-in components [:config :message-consumption-timeout-ms] 30000)
+                                      :interrupt? true}
+                                     ((:handler-fn consumer) {:message    (s/validate (:schema consumer) (dissoc message' :meta))
+                                                              :components components}))
+                    (log/debug ::message-handled {:queue   queue
+                                                  :message (dissoc message :body)})
+                    (sqs/delete-message (assoc message :queue-url queue-url))
+                    (catch Exception ex-handling-message
+                      (log/error ::exception-while-handling-aws-sqs-message ex-handling-message)))))
+              (catch Exception ex-in
+                (log/error ex-in))))))
+      (catch Exception ex-ext
+        (log/error ex-ext)))))
 
 (s/defmethod consume! :test
-  [{:keys [switch components consumers consumed-messages produced-messages]}]
-  (let [queues (-> components :config :queues)]
-    (doseq [queue queues]
-      (future
-        (while @switch
-          (let [messages (fetch-messages-waiting-to-be-processed! queue produced-messages consumed-messages)]
-            (doseq [message messages]
-              (binding [common-traceability/*correlation-id* (-> message
-                                                                 :payload
-                                                                 :meta
-                                                                 :correlation-id
-                                                                 common-traceability/correlation-id-appended)]
-                (try
-                  (let [{:keys [handler-fn schema]} (get consumers queue)]
+  [{:keys [switch components consumed-messages produced-messages queue consumer]}]
+  (while @switch
+    (let [messages (fetch-messages-waiting-to-be-processed! queue produced-messages consumed-messages)]
+      (doseq [message messages]
+        (binding [common-traceability/*correlation-id* (-> message
+                                                           :payload
+                                                           :meta
+                                                           :correlation-id
+                                                           common-traceability/correlation-id-appended)]
+          (try
+            (s/validate (:schema consumer) (-> message :payload (dissoc message :meta)))
 
-                    (s/validate schema (-> message :payload (dissoc message :meta)))
+            ((:handler-fn consumer) {:message    (-> message :payload (dissoc message :meta))
+                                     :components components})
 
-                    (handler-fn {:message    (-> message :payload (dissoc message :meta))
-                                 :components components})
+            (log/debug ::message-handled message)
 
-                    (log/debug ::message-handled message)
+            (commit-message-as-consumed! message consumed-messages)
+            (catch Exception ex
+              (log/error ex))))))
+    (Thread/sleep 10)))
 
-                    (commit-message-as-consumed! message consumed-messages))
-                  (catch Exception ex
-                    (log/error ex))))))
-          (Thread/sleep 10))))))
+(defn ensure-consumers-threads-are-up!
+  [consumers-thread-pool
+   switch
+   consumers
+   components]
+  (doseq [queue (keys @consumers-thread-pool)]
+    (if (< (->> (get @consumers-thread-pool queue) (filter #(not (future-done? %))) count)
+           (get-in components [:config :queues queue :parallel-consumers] 4))
+      (do
+        (log/info ::consumers-threads-count-bellow-treshold :starting-new-consumer-thread :queue queue)
+        (swap! consumers-thread-pool
+               update queue conj (future (consume! (medley/assoc-some {:switch      switch
+                                                                       :consumer    (get consumers queue)
+                                                                       :queue       queue
+                                                                       :components  components
+                                                                       :current-env (-> components :config :current-env)}
+                                                                      :produced-messages (when (= (-> components :config :current-env) :test)
+                                                                                           (-> components :producer :produced-messages))
+                                                                      :consumed-messages (when (= (-> components :config :current-env) :test)
+                                                                                           (atom [])))))))
+      (log/info ::all-expected-consumers-threads-are-up-and-running :queue queue))))
 
 (defmethod ig/init-key ::sqs-consumer
   [_ {:keys [components consumers]}]
   (log/info :starting ::sqs-consumer)
-  (let [switch (atom true)]
+  (let [switch (atom true)
+        queues (-> components :config :queues keys)
+        consumers-thread-pool (atom (reduce (fn [acc cur]
+                                              (assoc acc cur [])) {} queues))
+        pool (at-at/mk-pool)]
 
-    (dotimes [thread-number (get-in components [:config :consumer-parallelism] 4)]
-      (log/info ::starting-consumer-thread thread-number)
-      (consume! (medley/assoc-some {:switch      switch
-                                    :consumers   consumers
-                                    :components  components
-                                    :current-env (-> components :config :current-env)}
-                                   :produced-messages (when (= (-> components :config :current-env) :test)
-                                                        (-> components :producer :produced-messages))
-                                   :consumed-messages (when (= (-> components :config :current-env) :test)
-                                                        (atom [])))))
+    (when (= (-> components :config :current-env) :prod)
+      (create-sqs-queues! queues))
+
+    (doseq [queue queues]
+      (dotimes [thread-number (get-in components [:config :queues queue :parallel-consumers] 4)]
+        (log/info ::starting-consumer-thread thread-number :queue queue)
+        (swap! consumers-thread-pool
+               update queue conj (future (consume! (medley/assoc-some {:switch      switch
+                                                                       :consumer    (get consumers queue)
+                                                                       :queue       queue
+                                                                       :components  components
+                                                                       :current-env (-> components :config :current-env)}
+                                                                      :produced-messages (when (= (-> components :config :current-env) :test)
+                                                                                           (-> components :producer :produced-messages))
+                                                                      :consumed-messages (when (= (-> components :config :current-env) :test)
+                                                                                           (atom []))))))))
+
+    (at-at/interspaced 1000 #(try (ensure-consumers-threads-are-up! consumers-thread-pool switch consumers components)
+                                  (catch Exception ex
+                                    (log/error ex))) pool)
 
     {:switch switch}))
 

--- a/src/common_clj/integrant_components/sqs_consumer.clj
+++ b/src/common_clj/integrant_components/sqs_consumer.clj
@@ -5,9 +5,9 @@
             [diehard.core :as dh]
             [integrant.core :as ig]
             [medley.core :as medley]
+            [overtone.at-at :as at-at]
             [schema.core :as s]
-            [taoensso.timbre :as log]
-            [overtone.at-at :as at-at])
+            [taoensso.timbre :as log])
   (:import (clojure.lang IFn)))
 
 (s/defschema Consumers
@@ -52,8 +52,8 @@
                   (try
                     (dh/with-timeout {:timeout-ms (get-in components [:config :message-consumption-timeout-ms] 30000)
                                       :interrupt? true}
-                                     ((:handler-fn consumer) {:message    (s/validate (:schema consumer) (dissoc message' :meta))
-                                                              :components components}))
+                      ((:handler-fn consumer) {:message    (s/validate (:schema consumer) (dissoc message' :meta))
+                                               :components components}))
                     (log/debug ::message-handled {:queue   queue
                                                   :message (dissoc message :body)})
                     (sqs/delete-message (assoc message :queue-url queue-url))

--- a/src/common_clj/integrant_components/sqs_consumer.clj
+++ b/src/common_clj/integrant_components/sqs_consumer.clj
@@ -52,8 +52,8 @@
                   (try
                     (dh/with-timeout {:timeout-ms (get-in components [:config :message-consumption-timeout-ms] 30000)
                                       :interrupt? true}
-                      ((:handler-fn consumer) {:message    (s/validate (:schema consumer) (dissoc message' :meta))
-                                               :components components}))
+                                     ((:handler-fn consumer) {:message    (s/validate (:schema consumer) (dissoc message' :meta))
+                                                              :components components}))
                     (log/debug ::message-handled {:queue   queue
                                                   :message (dissoc message :body)})
                     (sqs/delete-message (assoc message :queue-url queue-url))

--- a/src/common_clj/integrant_components/sqs_producer.clj
+++ b/src/common_clj/integrant_components/sqs_producer.clj
@@ -30,7 +30,7 @@
   (log/info :starting ::sqs-producer)
 
   (when (= (-> components :config :current-env) :prod)
-    (component.sqs-consumer/create-sqs-queues! (-> components :config :queues))
+    (component.sqs-consumer/create-sqs-queues! (-> components :config :queues keys))
     (try (sqs/list-queues)
          (catch Exception ex
            (log/error :invalid-credentials :exception ex)


### PR DESCRIPTION
### Changed

- Now you can control the number of parallel consumer threads for each queue on `AWS SQS Consumer` component
  (Integrant).