### PR TITLE
Change some logs to better writing levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [30.63.70] - 2024-09-22
+
+### Changed
+
+- Instead of logging (at INFO level) each number of consumers threads up  `AWS SQS Consumer component (Integrant)`
+  validation, now we are logging that info at DEBUG level.
+
 ## [30.63.69] - 2024-09-20
 
 ### Changed
@@ -959,7 +966,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v30.63.69...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v30.63.70...HEAD
+
+[30.63.70]: https://github.com/macielti/common-clj/compare/v30.63.69...v30.63.70
 
 [30.63.69]: https://github.com/macielti/common-clj/compare/v29.63.69...v30.63.69
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "30.63.69"
+(defproject net.clojars.macielti/common-clj "30.63.70"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/common_clj/integrant_components/sqs_consumer.clj
+++ b/src/common_clj/integrant_components/sqs_consumer.clj
@@ -96,7 +96,7 @@
     (if (< (->> (get @consumers-thread-pool queue) (filter #(not (future-done? %))) count)
            (get-in components [:config :queues queue :parallel-consumers] 4))
       (do
-        (log/info ::consumers-threads-count-bellow-treshold :starting-new-consumer-thread :queue queue)
+        (log/warn ::consumers-threads-count-bellow-treshold :starting-new-consumer-thread :queue queue)
         (swap! consumers-thread-pool
                update queue conj (future (consume! (medley/assoc-some {:switch      switch
                                                                        :consumer    (get consumers queue)
@@ -107,7 +107,7 @@
                                                                                            (-> components :producer :produced-messages))
                                                                       :consumed-messages (when (= (-> components :config :current-env) :test)
                                                                                            (atom [])))))))
-      (log/info ::all-expected-consumers-threads-are-up-and-running :queue queue))))
+      (log/debug ::all-expected-consumers-threads-are-up-and-running :queue queue))))
 
 (defmethod ig/init-key ::sqs-consumer
   [_ {:keys [components consumers]}]

--- a/src/common_clj/integrant_components/sqs_consumer.clj
+++ b/src/common_clj/integrant_components/sqs_consumer.clj
@@ -52,8 +52,8 @@
                   (try
                     (dh/with-timeout {:timeout-ms (get-in components [:config :message-consumption-timeout-ms] 30000)
                                       :interrupt? true}
-                                     ((:handler-fn consumer) {:message    (s/validate (:schema consumer) (dissoc message' :meta))
-                                                              :components components}))
+                      ((:handler-fn consumer) {:message    (s/validate (:schema consumer) (dissoc message' :meta))
+                                               :components components}))
                     (log/debug ::message-handled {:queue   queue
                                                   :message (dissoc message :body)})
                     (sqs/delete-message (assoc message :queue-url queue-url))


### PR DESCRIPTION
### Changed

- Instead of logging (at INFO level) each number of consumers threads up  `AWS SQS Consumer component (Integrant)`
  validation, now we are logging that info at DEBUG level.