### PR TITLE
Add interceptor for customer identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [30.64.70] - 2024-10-02
+
+### Added
+
+- Added `common-clj.io.interceptors.customer` namespace to hold customer identification specific interceptors.
+
 ## [30.63.70] - 2024-09-22
 
 ### Changed
@@ -966,7 +972,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v30.63.70...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v30.64.70...HEAD
+
+[30.64.70]: https://github.com/macielti/common-clj/compare/v30.63.70...v30.64.70
 
 [30.63.70]: https://github.com/macielti/common-clj/compare/v30.63.69...v30.63.70
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "30.63.70"
+(defproject net.clojars.macielti/common-clj "30.64.70"
   :description "Just common Clojure code that I use across projects"
   :url "https://github.com/macielti/common-clj"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/common_clj/io/interceptors/customer.clj
+++ b/src/common_clj/io/interceptors/customer.clj
@@ -1,0 +1,43 @@
+(ns common-clj.io.interceptors.customer
+  (:require [buddy.sign.jwt :as jwt]
+            [camel-snake-kebab.core :as camel-snake-kebab]
+            [clojure.string :as str]
+            [common-clj.error.core :as common-error]
+            [schema.core :as s])
+  (:import (clojure.lang ExceptionInfo)
+           (java.util UUID)))
+
+(s/defschema CustomerIdentity
+  {:customer/id    s/Uuid
+   :customer/roles [s/Keyword]})
+
+(s/defn ^:private wire-jwt->customer-identity :- CustomerIdentity
+  [jwt-wire :- s/Str
+   jwt-secret :- s/Str]
+  (try (let [{:keys [id roles]} (:customer (jwt/unsign jwt-wire jwt-secret))]
+         {:customer/id    (UUID/fromString id)
+          :customer/roles (map camel-snake-kebab/->kebab-case-keyword roles)})
+       (catch ExceptionInfo _ (common-error/http-friendly-exception 422
+                                                                    "invalid-jwt"
+                                                                    "Invalid JWT"
+                                                                    "Invalid JWT"))))
+
+(def identity-interceptor
+  {:name  ::identity-interceptor
+   :enter (fn [{{{:keys [config]} :components
+                 headers          :headers} :request :as context}]
+            (assoc-in context [:request :customer]
+                      (wire-jwt->customer-identity (-> (get headers "authorization")
+                                                       (str/split #" ")
+                                                       last) (:jwt-secret config))))})
+
+(s/defn required-roles-interceptor
+  [required-roles :- [s/Keyword]]
+  {:name  ::required-roles-interceptor
+   :enter (fn [{{{customer-roles :customer/roles} :customer} :request :as context}]
+            (if (empty? (clojure.set/difference (set required-roles) (set customer-roles)))
+              context
+              (common-error/http-friendly-exception 403
+                                                    "insufficient-roles"
+                                                    "Insufficient privileges/roles/permission"
+                                                    "Insufficient privileges/roles/permission")))})


### PR DESCRIPTION
### Added

- Added `common-clj.io.interceptors.customer` namespace to hold customer identification specific interceptors.