### PR TITLE
Use clj-http-lite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [37.71.71] - 2024-11-10
+
+### Changed
+
+- Replaced clj-http with clj-http-lite for better compatibility with GraalVM.
+
 ## [37.71.70] - 2024-11-08
 
 ### Removed
@@ -1062,7 +1068,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v37.71.70...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v37.71.71...HEAD
+
+[37.71.71]: https://github.com/macielti/common-clj/compare/v37.71.70...v37.71.71
 
 [37.71.70]: https://github.com/macielti/common-clj/compare/v36.71.70...v37.71.70
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "37.71.70"
+(defproject net.clojars.macielti/common-clj "37.71.71"
 
   :description "Just common Clojure code that I use across projects"
 
@@ -11,6 +11,7 @@
 
   :dependencies [[org.clojure/clojure "1.12.0"]
                  [morse "0.4.3"]
+                 [org.clj-commons/clj-http-lite "1.0.13"]
                  [prismatic/schema-generators "0.1.5"]
                  [siili/humanize "0.1.1"]
                  [camel-snake-kebab "0.4.3"]

--- a/src/common_clj/integrant_components/http_client.clj
+++ b/src/common_clj/integrant_components/http_client.clj
@@ -1,7 +1,7 @@
 (ns common-clj.integrant-components.http-client
   (:require [camel-snake-kebab.core :as camel-snake-kebab]
             [cheshire.core :as json]
-            [clj-http.client :as client]
+            [clj-http.lite.client :as client]
             [clojure.tools.logging :as log]
             [iapetos.core :as prometheus]
             [integrant.core :as ig]
@@ -11,7 +11,7 @@
 (def method->request-fn
   {:post   client/post
    :get    client/get
-   :patch  client/patch
+   :put    client/put
    :delete client/delete})
 
 (defmulti request!


### PR DESCRIPTION
This pull request includes updates to improve compatibility with GraalVM by replacing `clj-http` with `clj-http-lite`, along with version updates and dependency additions.

### Dependency and Version Updates:

* [`project.clj`](diffhunk://#diff-274071745a4e2a04b647d79d500537e6dc13eee54f44d0426140026293701d1bL1-R1): Updated project version to `37.71.71` and added `clj-http-lite` dependency. [[1]](diffhunk://#diff-274071745a4e2a04b647d79d500537e6dc13eee54f44d0426140026293701d1bL1-R1) [[2]](diffhunk://#diff-274071745a4e2a04b647d79d500537e6dc13eee54f44d0426140026293701d1bR14)

### HTTP Client Changes:

* [`src/common_clj/integrant_components/http_client.clj`](diffhunk://#diff-65b0ff161bfdf38c6822bf685de58076ab443e08c642b5caec80b1451b358aefL4-R4): Replaced `clj-http` with `clj-http-lite` and updated the HTTP method mapping. [[1]](diffhunk://#diff-65b0ff161bfdf38c6822bf685de58076ab443e08c642b5caec80b1451b358aefL4-R4) [[2]](diffhunk://#diff-65b0ff161bfdf38c6822bf685de58076ab443e08c642b5caec80b1451b358aefL14-R14)

### Documentation Updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13): Documented the replacement of `clj-http` with `clj-http-lite` and updated version references. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1065-R1073)