### PR TITLE
Added `:http-request-in-handle-timing` Prometheus component metric to measure the time spent while handling http requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [38.72.71] - 2024-11-16
+
+### Added
+
+- Added `:http-request-in-handle-timing` Prometheus component metric to measure the time spent while handling http
+  requests.
+
 ## [38.71.71] - 2024-11-10
 
 ### Removed
@@ -1074,7 +1081,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v38.71.71...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v38.72.71...HEAD
+
+[38.72.71]: https://github.com/macielti/common-clj/compare/v38.71.71...v38.72.71
 
 [38.71.71]: https://github.com/macielti/common-clj/compare/v37.71.71...v38.71.71
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "38.71.71"
+(defproject net.clojars.macielti/common-clj "38.72.71"
 
   :description "Just common Clojure code that I use across projects"
 

--- a/src/common_clj/integrant_components/prometheus.clj
+++ b/src/common_clj/integrant_components/prometheus.clj
@@ -15,7 +15,8 @@
      :body   "Not Authorized"}))
 
 (def default-metrics
-  [(prometheus/counter :http-request-response {:labels [:status :service :endpoint]})])
+  [(prometheus/counter :http-request-response {:labels [:status :service :endpoint]})
+   (prometheus/histogram :http-request-in-handle-timing {:labels [:service :endpoint]})])
 
 (defmethod ig/init-key ::prometheus
   [_ {:keys [metrics]}]


### PR DESCRIPTION
This pull request includes several updates to the project, primarily focusing on adding a new Prometheus metric, updating the project version, and modifying the changelog to reflect these changes.

### Version Updates:
* Updated the project version in `project.clj` from `38.71.71` to `38.72.71`.

### New Features:
* Added a new Prometheus component metric `:http-request-in-handle-timing` to measure the time spent handling HTTP requests in `src/common_clj/integrant_components/prometheus.clj`.

### Documentation Updates:
* Updated `CHANGELOG.md` to include the new version `38.72.71` and document the addition of the new Prometheus metric.
* Updated the comparison links in `CHANGELOG.md` to reflect the new version.