### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [38.72.72] - 2024-11-16
+
+### Changed
+
+- Bump dependencies.
+
 ## [38.72.71] - 2024-11-16
 
 ### Added
@@ -1081,7 +1087,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v38.72.71...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v38.72.72...HEAD
+
+[38.72.72]: https://github.com/macielti/common-clj/compare/v38.72.71...v38.72.72
 
 [38.72.71]: https://github.com/macielti/common-clj/compare/v38.71.71...v38.72.71
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "38.72.71"
+(defproject net.clojars.macielti/common-clj "38.72.72"
 
   :description "Just common Clojure code that I use across projects"
 
@@ -18,7 +18,7 @@
                  [cheshire "5.13.0"]
                  [metosin/schema-tools "0.13.1"]
                  [clj-commons/iapetos "0.1.14"]
-                 [clojure.java-time "1.4.2"]
+                 [clojure.java-time "1.4.3"]
                  [clj-rate-limiter "0.1.6-RC1"]
                  [dev.weavejester/medley "1.8.1"]
                  [hara/io.scheduler "3.0.12"]
@@ -35,13 +35,13 @@
                    :test-paths     ^:replace ["test/unit" "test/integration" "test/helpers"]
 
                    :plugins        [[lein-cloverage "1.2.4"]
-                                    [com.github.clojure-lsp/lein-clojure-lsp "1.4.13"]
+                                    [com.github.clojure-lsp/lein-clojure-lsp "1.4.15"]
                                     [com.github.liquidz/antq "RELEASE"]]
 
-                   :dependencies   [[net.clojars.macielti/common-test-clj "1.1.0"]
+                   :dependencies   [[net.clojars.macielti/common-test-clj "1.1.1"]
                                     [org.slf4j/slf4j-api "2.0.16"]
                                     [ch.qos.logback/logback-classic "1.5.12"]
-                                    [net.clojars.macielti/service-component "0.2.0"]
+                                    [net.clojars.macielti/service-component "1.4.2"]
                                     [nubank/matcher-combinators "3.9.1"]
                                     [clj-http-fake "1.0.4"]
                                     [nubank/mockfn "0.7.0"]


### PR DESCRIPTION
This pull request updates the project version and several dependencies in the `project.clj` file, and also updates the `CHANGELOG.md` to reflect these changes.

### Version and Dependency Updates:

* Updated project version from `38.72.71` to `38.72.72` in `project.clj`.
* Updated `clojure.java-time` dependency from `1.4.2` to `1.4.3`.
* Updated `lein-clojure-lsp` plugin from `1.4.13` to `1.4.15`.
* Updated `common-test-clj` dependency from `1.1.0` to `1.1.1`.
* Updated `service-component` dependency from `0.2.0` to `1.4.2`.

### Changelog Updates:

* Added a new version entry `[38.72.72] - 2024-11-16` with a note about bumping dependencies in `CHANGELOG.md`.
* Updated the comparison links to reflect the new version `38.72.72` in `CHANGELOG.md`.