### PR TITLE
Added `http-request-in-handle-timing-v2` summary metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1100,7 +1100,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v38.72.72...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v39.72.72...HEAD
+
+[39.72.72]: https://github.com/macielti/common-clj/compare/v38.72.72...v39.72.72
 
 [38.72.72]: https://github.com/macielti/common-clj/compare/v38.72.71...v38.72.72
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [39.72.72] - 2024-11-17
+
+### Added
+
+- Added `:http-request-in-handle-timing-v2` (summary) Prometheus component metric to measure the time spent while
+  handling http
+  requests.
+
+### Removed
+
+- Removed `:http-request-in-handle-timing` Prometheus component metric to measure the time spent while handling http
+  requests.
+
 ## [38.72.72] - 2024-11-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ of [keepachangelog.com](http://keepachangelog.com/).
 ### Added
 
 - Added `:http-request-in-handle-timing-v2` (summary) Prometheus component metric to measure the time spent while
-  handling http
-  requests.
+  handling http requests.
 
 ### Removed
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "38.72.72"
+(defproject net.clojars.macielti/common-clj "39.72.72"
 
   :description "Just common Clojure code that I use across projects"
 

--- a/src/common_clj/integrant_components/prometheus.clj
+++ b/src/common_clj/integrant_components/prometheus.clj
@@ -16,7 +16,8 @@
 
 (def default-metrics
   [(prometheus/counter :http-request-response {:labels [:status :service :endpoint]})
-   (prometheus/histogram :http-request-in-handle-timing {:labels [:service :endpoint]})])
+   (prometheus/summary :http-request-in-handle-timing-v2 {:labels    [:service :endpoint]
+                                                          :quantiles {0.5 0.05, 0.9 0.1, 0.99 0.001}})])
 
 (defmethod ig/init-key ::prometheus
   [_ {:keys [metrics]}]


### PR DESCRIPTION
This pull request includes updates to the `common-clj` project, primarily focusing on Prometheus metrics and version updates. The most important changes include adding a new Prometheus metric, removing an old one, and updating the project version.

Prometheus metrics updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R20): Added a new Prometheus component metric `:http-request-in-handle-timing-v2` to measure the time spent handling HTTP requests. Removed the old metric `:http-request-in-handle-timing` for the same purpose.
* [`src/common_clj/integrant_components/prometheus.clj`](diffhunk://#diff-cf8460f630118722cf0fa30f1b27a09b4e6537066352646cc805675d9a08db81L19-R20): Replaced the old Prometheus histogram metric `:http-request-in-handle-timing` with a new summary metric `:http-request-in-handle-timing-v2`, which includes quantiles.

Version update:

* [`project.clj`](diffhunk://#diff-274071745a4e2a04b647d79d500537e6dc13eee54f44d0426140026293701d1bL1-R1): Updated the project version from `38.72.72` to `39.72.72`.