### PR TITLE
Properly use binding pedestal interceptor feature for cid handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [40.72.72] - 2024-11-17
+
+### Changed
+
+- Properly use bindings feature from Pedestal interceptors for CID handling.
+
 ## [39.72.72] - 2024-11-17
 
 ### Added
@@ -1099,7 +1105,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v39.72.72...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v40.72.72...HEAD
+
+[40.72.72]: https://github.com/macielti/common-clj/compare/v39.72.72...v40.72.72
 
 [39.72.72]: https://github.com/macielti/common-clj/compare/v38.72.72...v39.72.72
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "39.72.72"
+(defproject net.clojars.macielti/common-clj "40.72.72"
 
   :description "Just common Clojure code that I use across projects"
 
@@ -41,7 +41,7 @@
                    :dependencies   [[net.clojars.macielti/common-test-clj "1.1.1"]
                                     [org.slf4j/slf4j-api "2.0.16"]
                                     [ch.qos.logback/logback-classic "1.5.12"]
-                                    [net.clojars.macielti/service-component "1.4.2"]
+                                    [net.clojars.macielti/service-component "2.4.2"]
                                     [nubank/matcher-combinators "3.9.1"]
                                     [clj-http-fake "1.0.4"]
                                     [nubank/mockfn "0.7.0"]

--- a/test/integration/integration/integrant_components/config_component_test.clj
+++ b/test/integration/integration/integrant_components/config_component_test.clj
@@ -31,8 +31,7 @@
 (s/deftest config-prod-component-test
   (testing "That we can define endpoints"
     (let [system (ig/init config-prod)]
-      (is (= {:bootstrap-server       "http://localhost:9092"
-              :current-env            :prod
+      (is (= {:current-env            :prod
               :service-authentication {:auth-server-base-url "https://example.com"
                                        :password             "random-password"
                                        :username             "service-name"}}
@@ -42,8 +41,7 @@
 (s/deftest config-test-component-test
   (testing "That we can define endpoints"
     (let [system (ig/init config-test)]
-      (is (= {:bootstrap-server                              "http://localhost:9092"
-              :current-env                                   :test
+      (is (= {:current-env                                   :test
               :dead-letter-queue-service-integration-enabled true
               :service                                       {:host "0.0.0.0"
                                                               :port 8000}

--- a/test/integration/traceability_test.clj
+++ b/test/integration/traceability_test.clj
@@ -1,0 +1,39 @@
+(ns traceability-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [is testing]]
+            [common-clj.integrant-components.config :as component.config]
+            [common-clj.integrant-components.routes :as component.routes]
+            [common-clj.traceability.core :as traceability]
+            [integrant.core :as ig]
+            [io.pedestal.test :as test]
+            [schema.test :as s]
+            [service-component.core :as component.service]))
+
+(def routes [["/test" :get [traceability/with-correlation-id-interceptor
+                            (fn [_]
+                              {:status 200
+                               :body   {:cid traceability/*correlation-id*}})]
+              :route-name :test]])
+
+(def system-components
+  {::component.config/config   {:path "test/resources/config.example.edn"
+                                :env  :test}
+   ::component.routes/routes   {:routes routes}
+   ::component.service/service {:components {:config (ig/ref ::component.config/config)
+                                             :routes (ig/ref ::component.routes/routes)}}})
+
+(s/deftest traceability-test
+  (let [system (ig/init system-components)
+        service-fn (-> system ::component.service/service :io.pedestal.http/service-fn)]
+
+    (testing "That we can fetch the test endpoint and access correlation-id"
+      (is (str/includes? (-> (test/response-for service-fn :get "/test")
+                             :body)
+                         "{\"cid\":\"DEFAULT.")))
+
+    (testing "That we can fetch the test endpoint and compose the current correlation-id based on the header"
+      (is (str/includes? (-> (test/response-for service-fn :get "/test" :headers {"x-correlation-id" "DEFAULT.29A296ED8418.CB66A52273E6"})
+                             :body)
+                         "DEFAULT.29A296ED8418.CB66A52273E6.")))
+
+    (ig/halt! system)))

--- a/test/resources/config.example.edn
+++ b/test/resources/config.example.edn
@@ -1,0 +1,3 @@
+{:test {:service-name "service-test"
+        :service      {:host "0.0.0.0"
+                       :port 8080}}}

--- a/test/resources/config_test.edn
+++ b/test/resources/config_test.edn
@@ -1,9 +1,7 @@
-{:prod {:bootstrap-server       "http://localhost:9092"
-        :service-authentication {:auth-server-base-url "https://example.com"
+{:prod {:service-authentication {:auth-server-base-url "https://example.com"
                                  :username             "service-name"
                                  :password             "random-password"}}
- :test {:bootstrap-server                              "http://localhost:9092"
-        :service-name                                  "test-service-name"
+ :test {:service-name                                  "test-service-name"
         :service                                       {:host "0.0.0.0"
                                                         :port 8000}
         :topics                                        ["test.example"]

--- a/test/unit/common_clj/integrant_components/config_test.clj
+++ b/test/unit/common_clj/integrant_components/config_test.clj
@@ -5,12 +5,10 @@
 
 (s/deftest config-file-test
   (testing "That we can read a config file"
-    (is (= {:prod {:bootstrap-server       "http://localhost:9092"
-                   :service-authentication {:auth-server-base-url "https://example.com"
+    (is (= {:prod {:service-authentication {:auth-server-base-url "https://example.com"
                                             :password             "random-password"
                                             :username             "service-name"}}
-            :test {:bootstrap-server                              "http://localhost:9092"
-                   :dead-letter-queue-service-integration-enabled true
+            :test {:dead-letter-queue-service-integration-enabled true
                    :service                                       {:host "0.0.0.0"
                                                                    :port 8000}
                    :service-authentication                        {:auth-server-base-url "https://example.com"


### PR DESCRIPTION
This pull request includes several changes to improve the traceability functionality and add integration tests. The most important changes include the addition of a correlation ID interceptor, creation of integration tests for traceability, and updates to configuration files.

Traceability improvements:

* [`src/common_clj/traceability/core.clj`](diffhunk://#diff-fc0c8cb8e2e720f28b8f94006a014008909208f130ef74b1137eae77e2de8e8fL23-R31): Added a new interceptor `with-correlation-id-interceptor` to handle correlation IDs using the `io.pedestal.interceptor` library.

Integration tests:

* [`test/integration/traceability_test.clj`](diffhunk://#diff-9cb8f3a0d34b0aaa02662d84d0e7f0129d39c31524566e717cc385300ffeaea7R1-R39): Added a new test namespace `traceability-test` with integration tests to verify the correlation ID functionality.

Configuration updates:

* [`test/resources/config.example.edn`](diffhunk://#diff-d23f39fa388c90738df58f8816f8d8f5f55010cc4f81078a5cad43a8ac1f27ecR1-R3): Added a new example configuration file for testing with service details.
* [`test/resources/config_test.edn`](diffhunk://#diff-bf80f0cb2516b092efdd3281e536eaaecaab3f2a0ef48d3c1b670c059f0a62a4L1-R4): Updated the test configuration file to remove the `bootstrap-server` entry and adjust the service configuration.