### PR TITLE
Added `LocalDateTimeWire` and `UuidWire` schema extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [41.73.72] - 2024-11-23
+
+### Added
+
+- Added `LocalDateTimeWire` and `UuidWire` schema extensions.
+
 ## [41.72.72] - 2024-11-19
 
 ### Removed
@@ -1111,7 +1117,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/comparev41.72.72...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v41.73.72...HEAD
+
+[41.73.72]: https://github.com/macielti/common-clj/compare/v41.72.72...v41.73.72
 
 [41.72.72]: https://github.com/macielti/common-clj/compare/v40.72.72...v41.72.72
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "41.72.72"
+(defproject net.clojars.macielti/common-clj "41.73.72"
 
   :description "Just common Clojure code that I use across projects"
 
@@ -25,9 +25,10 @@
                  [amazonica "0.3.167"]
                  [diehard "0.11.12"]
                  [overtone/at-at "1.4.65"]
-                 [commons-io/commons-io "2.17.0"]
+                 [commons-io/commons-io "2.18.0"]
                  [org.clojure/tools.logging "1.3.0"]
-                 [org.clojure/tools.reader "1.5.0"]]
+                 [org.clojure/tools.reader "1.5.0"]
+                 [danlentz/clj-uuid "0.2.0"]]
 
   :profiles {:dev {:resource-paths ^:replace ["test/resources"]
 
@@ -37,7 +38,7 @@
                                     [com.github.clojure-lsp/lein-clojure-lsp "1.4.15"]
                                     [com.github.liquidz/antq "RELEASE"]]
 
-                   :dependencies   [[net.clojars.macielti/common-test-clj "1.1.1"]
+                   :dependencies   [[net.clojars.macielti/common-test-clj "3.1.2"]
                                     [org.slf4j/slf4j-api "2.0.16"]
                                     [ch.qos.logback/logback-classic "1.5.12"]
                                     [net.clojars.macielti/service-component "2.4.2"]

--- a/src/common_clj/schema/extensions.clj
+++ b/src/common_clj/schema/extensions.clj
@@ -1,6 +1,15 @@
 (ns common-clj.schema.extensions
-  (:require [schema.core :as s]))
+  (:require [schema.core :as s]
+            [clj-uuid]))
 
 (s/defschema LocalDateWire
   "Example: '2024-09-07'"
-  (s/constrained s/Str #(re-matches #"^\d{4}-\d{2}-\d{2}T\d{2}$" %)))
+  (s/constrained s/Str #(re-matches #"^\d{4}-\d{2}-\d{2}$" %)))
+
+(s/defschema LocalDateTimeWire
+  "Example: '2024-11-21T04:56:24.605402'"
+  (s/constrained s/Str #(re-matches #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$" %)))
+
+(s/defschema UuidWire
+  "Example: '9c97de3b-ac65-44b2-ba4f-b65f8778e514'"
+  (s/constrained s/Str clj-uuid/uuid-string?))

--- a/src/common_clj/schema/extensions.clj
+++ b/src/common_clj/schema/extensions.clj
@@ -1,6 +1,6 @@
 (ns common-clj.schema.extensions
-  (:require [schema.core :as s]
-            [clj-uuid]))
+  (:require [clj-uuid]
+            [schema.core :as s]))
 
 (s/defschema LocalDateWire
   "Example: '2024-09-07'"


### PR DESCRIPTION
This pull request includes updates to the project version, dependencies, and schema extensions. The most important changes include adding new schema extensions, updating project dependencies, and modifying the version number.

### Schema Extensions:
* Added `LocalDateTimeWire` and `UuidWire` schema extensions in `src/common_clj/schema/extensions.clj`.
* Updated `LocalDateWire` schema to correct the date format.

### Dependencies:
* Updated `commons-io` dependency from version `2.17.0` to `2.18.0` in `project.clj`.
* Added `danlentz/clj-uuid` dependency version `0.2.0` in `project.clj`.
* Updated `net.clojars.macielti/common-test-clj` dependency from version `1.1.1` to `3.1.2` in `project.clj`.

### Versioning:
* Updated project version from `41.72.72` to `41.73.72` in `project.clj`.
* Updated `CHANGELOG.md` to reflect the new version `41.73.72` and added a link for the new version comparison. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1114-R1122)