### PR TITLE
More flexible `LocalDateTimeWire` schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [41.73.73] - 2024-11-23
+
+### Fixed
+
+- More flexible `LocalDateTimeWire` schema.
+
 ## [41.73.72] - 2024-11-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1123,7 +1123,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v41.73.72...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v41.73.73...HEAD
+
+[41.73.73]: https://github.com/macielti/common-clj/compare/v41.73.72...v41.73.73
 
 [41.73.72]: https://github.com/macielti/common-clj/compare/v41.72.72...v41.73.72
 

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                                     [com.github.clojure-lsp/lein-clojure-lsp "1.4.15"]
                                     [com.github.liquidz/antq "RELEASE"]]
 
-                   :dependencies   [[net.clojars.macielti/common-test-clj "3.1.2"]
+                   :dependencies   [[net.clojars.macielti/common-test-clj "3.2.3"]
                                     [org.slf4j/slf4j-api "2.0.16"]
                                     [ch.qos.logback/logback-classic "1.5.12"]
                                     [net.clojars.macielti/service-component "2.4.2"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "41.73.72"
+(defproject net.clojars.macielti/common-clj "41.73.73"
 
   :description "Just common Clojure code that I use across projects"
 

--- a/src/common_clj/schema/extensions.clj
+++ b/src/common_clj/schema/extensions.clj
@@ -7,8 +7,9 @@
   (s/constrained s/Str #(re-matches #"^\d{4}-\d{2}-\d{2}$" %)))
 
 (s/defschema LocalDateTimeWire
-  "Example: '2024-11-21T04:56:24.605402'"
-  (s/constrained s/Str #(re-matches #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$" %)))
+  "Example: '2024-11-21T04:56:24.605402' or '2024-11-21T04:56'"
+  (s/constrained s/Str #(or (re-matches #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$" %)
+                            (re-matches #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$" %))))
 
 (s/defschema UuidWire
   "Example: '9c97de3b-ac65-44b2-ba4f-b65f8778e514'"


### PR DESCRIPTION
This pull request includes several changes to update the version and improve the flexibility of the `LocalDateTimeWire` schema. The most important changes are summarized below:

### Version Update:

* Updated the project version from `41.73.72` to `41.73.73` in `project.clj`.
* Updated the dependency version for `net.clojars.macielti/common-test-clj` from `3.1.2` to `3.2.3` in `project.clj`.

### Schema Improvement:

* Modified the `LocalDateTimeWire` schema in `src/common_clj/schema/extensions.clj` to accept both precise and less precise datetime formats.

### Documentation Update:

* Added a new version entry `[41.73.73] - 2024-11-23` in `CHANGELOG.md` and updated the comparison links. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1120-R1128)