### PR TITLE
More support to different formats for `LocalDateTimeWire` schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [41.74.73] - 2024-11-23
+
+### Fixed
+
+- More support to different formats for `LocalDateTimeWire` schema.
+
 ## [41.73.73] - 2024-11-23
 
 ### Fixed
@@ -1123,7 +1129,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v41.73.73...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v41.74.73...HEAD
+
+[41.74.73]: https://github.com/macielti/common-clj/compare/v41.73.73...v41.74.73
 
 [41.73.73]: https://github.com/macielti/common-clj/compare/v41.73.72...v41.73.73
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "41.73.73"
+(defproject net.clojars.macielti/common-clj "41.74.73"
 
   :description "Just common Clojure code that I use across projects"
 

--- a/src/common_clj/schema/extensions.clj
+++ b/src/common_clj/schema/extensions.clj
@@ -8,7 +8,7 @@
 
 (s/defschema LocalDateTimeWire
   "Example: '2024-11-21T04:56:24.605402' or '2024-11-21T04:56'"
-  (s/constrained s/Str #(or (re-matches #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$" %)
+  (s/constrained s/Str #(or (re-matches #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6,9}$" %)
                             (re-matches #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$" %))))
 
 (s/defschema UuidWire


### PR DESCRIPTION
This pull request includes updates to the versioning, changelog, and schema definitions in the project. The most important changes are the version bump, changelog updates, and schema modifications.

Versioning and changelog updates:

* Updated project version from `41.73.73` to `41.74.73` in `project.clj`.
* Added a new version entry `[41.74.73] - 2024-11-23` in `CHANGELOG.md` with details about the fixed support for different formats for `LocalDateTimeWire` schema.
* Updated the comparison link for the unreleased version and added the link for the new version in `CHANGELOG.md`.

Schema modifications:

* Enhanced the `LocalDateTimeWire` schema to support additional date-time formats with nanosecond precision in `src/common_clj/schema/extensions.clj`.