### PR TITLE
Removed require to `io.pedestal.log`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [41.74.74] - 2024-11-26
+
+### Fixed
+
+- Removed require to `io.pedestal.log`.
+
 ## [41.74.73] - 2024-11-23
 
 ### Fixed
@@ -1129,7 +1135,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v41.74.73...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v41.74.74...HEAD
+
+[41.74.74]: https://github.com/macielti/common-clj/compare/v41.74.73...v41.74.74
 
 [41.74.73]: https://github.com/macielti/common-clj/compare/v41.73.73...v41.74.73
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "41.74.73"
+(defproject net.clojars.macielti/common-clj "41.74.74"
 
   :description "Just common Clojure code that I use across projects"
 
@@ -25,9 +25,7 @@
                  [amazonica "0.3.167"]
                  [diehard "0.11.12"]
                  [overtone/at-at "1.4.65"]
-                 [commons-io/commons-io "2.18.0"]
                  [org.clojure/tools.logging "1.3.0"]
-                 [org.clojure/tools.reader "1.5.0"]
                  [danlentz/clj-uuid "0.2.0"]]
 
   :profiles {:dev {:resource-paths ^:replace ["test/resources"]

--- a/src/common_clj/integrant_components/aws_auth.clj
+++ b/src/common_clj/integrant_components/aws_auth.clj
@@ -1,7 +1,7 @@
 (ns common-clj.integrant-components.aws-auth
   (:require [amazonica.core :as aws]
-            [integrant.core :as ig]
-            [io.pedestal.log :as log]))
+            [clojure.tools.logging :as log]
+            [integrant.core :as ig]))
 
 (defmethod ig/init-key ::aws-auth
   [_ {:keys [components]}]


### PR DESCRIPTION
This pull request includes several updates to the `common-clj` project, focusing on version updates, dependency removals, and logging adjustments. The most important changes include updating the project version, modifying dependencies, and updating the changelog.

Version and Changelog Updates:

* Updated the project version in `project.clj` from `41.74.73` to `41.74.74`.
* Updated the changelog to reflect the new version `41.74.74` and added a new entry for the fixed issue [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1132-R1140).

Dependency Removals:

* Removed the `io.pedestal.log` dependency and replaced it with `clojure.tools.logging` in `src/common_clj/integrant_components/aws_auth.clj`.
* Removed `commons-io` and `tools.reader` dependencies from `project.clj`.