### PR TITLE
 Refactored `common-clj.traceability.core`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on: [ push ]
 jobs:
   test:
     name: Running Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [43.74.74] - 2025-01-25
+
+### Changed
+
+- Refactored `common-clj.traceability.core` to be more flexible allowing more options to manipulate the
+  `correlation-id`.
+
 ## [42.74.74] - 2025-01-08
 
 ### Removed
@@ -1142,7 +1149,9 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - Add `loose-schema` function.
 
-[Unreleased]: https://github.com/macielti/common-clj/compare/v42.74.74...HEAD
+[Unreleased]: https://github.com/macielti/common-clj/compare/v43.74.74...HEAD
+
+[43.74.74]: https://github.com/macielti/common-clj/compare/v42.74.74...v43.74.74
 
 [42.74.74]: https://github.com/macielti/common-clj/compare/v41.74.74...v42.74.74
 

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,8 @@
                  [integrant "0.13.1"]
                  [diehard "0.11.12"]
                  [org.clojure/tools.logging "1.3.0"]
-                 [danlentz/clj-uuid "0.2.0"]]
+                 [danlentz/clj-uuid "0.2.0"]
+                 [commons-io/commons-io "2.18.0"]]
 
   :profiles {:dev {:resource-paths ^:replace ["test/resources"]
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "42.74.74"
+(defproject net.clojars.macielti/common-clj "43.74.74"
 
   :description "Just common Clojure code that I use across projects"
 
@@ -31,12 +31,12 @@
                    :test-paths     ^:replace ["test/unit" "test/integration" "test/helpers"]
 
                    :plugins        [[lein-cloverage "1.2.4"]
-                                    [com.github.clojure-lsp/lein-clojure-lsp "1.4.15"]
+                                    [com.github.clojure-lsp/lein-clojure-lsp "1.4.16"]
                                     [com.github.liquidz/antq "RELEASE"]]
 
-                   :dependencies   [[net.clojars.macielti/common-test-clj "3.2.3"]
+                   :dependencies   [[net.clojars.macielti/common-test-clj "5.2.3"]
                                     [org.slf4j/slf4j-api "2.0.16"]
-                                    [ch.qos.logback/logback-classic "1.5.12"]
+                                    [ch.qos.logback/logback-classic "1.5.16"]
                                     [net.clojars.macielti/service-component "2.4.2"]
                                     [nubank/matcher-combinators "3.9.1"]
                                     [clj-http-fake "1.0.4"]

--- a/test/integration/traceability_test.clj
+++ b/test/integration/traceability_test.clj
@@ -9,10 +9,10 @@
             [schema.test :as s]
             [service-component.core :as component.service]))
 
-(def routes [["/test" :get [traceability/with-correlation-id-interceptor
-                            (fn [_]
+(def routes [["/test" :get [traceability/with-correlation-id-http-interceptor
+                            (fn [_context]
                               {:status 200
-                               :body   {:cid traceability/*correlation-id*}})]
+                               :body   {:cid (traceability/current-correlation-id!)}})]
               :route-name :test]])
 
 (def system-components
@@ -29,11 +29,11 @@
     (testing "That we can fetch the test endpoint and access correlation-id"
       (is (str/includes? (-> (test/response-for service-fn :get "/test")
                              :body)
-                         "{\"cid\":\"DEFAULT.")))
+                         "{\"cid\":\"DEFAULT")))
 
     (testing "That we can fetch the test endpoint and compose the current correlation-id based on the header"
       (is (str/includes? (-> (test/response-for service-fn :get "/test" :headers {"x-correlation-id" "DEFAULT.29A296ED8418.CB66A52273E6"})
                              :body)
-                         "DEFAULT.29A296ED8418.CB66A52273E6.")))
+                         "DEFAULT.29A296ED8418.CB66A52273E6")))
 
     (ig/halt! system)))

--- a/test/unit/common_clj/traceability/core_test.clj
+++ b/test/unit/common_clj/traceability/core_test.clj
@@ -1,21 +1,139 @@
 (ns common-clj.traceability.core-test
-  (:require [clojure.test :refer [is]]
+  (:require [clojure.test :refer [is testing]]
             [common-clj.traceability.core :as common-traceability]
+            [io.pedestal.interceptor :as interceptor]
+            [io.pedestal.interceptor.chain :as chain]
+            [matcher-combinators.test :refer [match?]]
             [mockfn.macros :as mfn]
             [schema.test :as s]))
 
-(s/deftest current-correlation-id-from-request-context-test
-  (is (= "DEFAULT.TEST"
-         (common-traceability/current-correlation-id-from-request-context
-          {:headers {"x-correlation-id" "default.test"}})))
+(s/deftest reset-correlation-id!-test
+  (common-traceability/reset-correlation-id!)
+  (testing "Given an existing correlation-id, we should be able to reset it to nil"
+    (common-traceability/correlation-id-appended!)
+    (is (match? string?
+                (common-traceability/correlation-id-appended!)))
+    (is (match? string?
+                @common-traceability/*correlation-id*))
+    (common-traceability/reset-correlation-id!)
+    (is (nil? @common-traceability/*correlation-id*))))
+
+(s/deftest set-correlation-id!-test
+  (common-traceability/reset-correlation-id!)
+  (testing "Should be able to explicitly set the correlation-id"
+    (is (= "DEFAULT.TEST"
+           (common-traceability/set-correlation-id! "default.test")))
+    (is (= "EDNALDO.PEREIRA"
+           (common-traceability/set-correlation-id! "ednaldo.pereira")))))
+
+(s/deftest current-correlation-id!-test
+  (common-traceability/reset-correlation-id!)
+  (testing "Given a empty correlation-id, we should get a default one"
+    (is (= "DEFAULT"
+           (common-traceability/current-correlation-id!))))
+  (testing "Given a set correlation-id, we should get the same one"
+    (common-traceability/set-correlation-id! "ednaldo.pereira")
+    (is (= "EDNALDO.PEREIRA"
+           (common-traceability/current-correlation-id!)))))
+
+(s/deftest correlation-id-appended!-test
+  (common-traceability/reset-correlation-id!)
   (mfn/providing [(random-uuid) #uuid "7835733a-83e1-46d1-94e4-7b84fb601d64"]
                  (is (= "DEFAULT.7B84FB601D64"
-                        (common-traceability/current-correlation-id-from-request-context
+                        (common-traceability/correlation-id-appended!)))
+                 (is (= "DEFAULT.7B84FB601D64.7B84FB601D64"
+                        (common-traceability/correlation-id-appended!)))))
+
+(s/deftest current-correlation-id-from-request-context-test
+  (common-traceability/reset-correlation-id!)
+  (is (= "DEFAULT.TEST"
+         (common-traceability/correlation-id-from-request-context
+          {:headers {"x-correlation-id" "default.test"}})))
+  (common-traceability/reset-correlation-id!)
+  (mfn/providing [(random-uuid) #uuid "7835733a-83e1-46d1-94e4-7b84fb601d64"]
+                 (is (= "DEFAULT"
+                        (common-traceability/correlation-id-from-request-context
                          {:headers {}})))))
 
-(s/deftest correlation-id-appended-test
-  (mfn/providing [(random-uuid) #uuid "7835733a-83e1-46d1-94e4-7b84fb601d64"]
-                 (is (= "MOCK.TEST.7B84FB601D64"
-                        (common-traceability/correlation-id-appended "MOCK.TEST"))))
+(defn handler-fn->interceptor
+  [handler-fn]
+  (interceptor/interceptor
+   {:name  ::test-interceptor
+    :enter handler-fn}))
 
-  (is (thrown? AssertionError (common-traceability/correlation-id-appended ""))))
+(def test-state (atom nil))
+
+(s/deftest with-correlation-id-http-interceptor-test
+  (testing "Given a HTTP request, we should be able to receive a correlation-id header"
+    (chain/execute {:request {:headers {"x-correlation-id" "INTERCEPTOR_HTTP_TEST.1998"}}}
+                   [common-traceability/with-correlation-id-http-interceptor
+                    (handler-fn->interceptor (fn [context]
+                                               (reset! test-state (common-traceability/current-correlation-id!))
+                                               context))])
+    (is (= "INTERCEPTOR_HTTP_TEST.1998"
+           @test-state)))
+
+  (testing "Given a HTTP request, we should be able to receive a correlation-id header - No conflict with main thread"
+    (chain/execute {:request {:headers {"x-correlation-id" "INTERCEPTOR_HTTP_TEST.1998.V2"}}}
+                   [common-traceability/with-correlation-id-http-interceptor
+                    (handler-fn->interceptor (fn [context]
+                                               (reset! test-state (common-traceability/current-correlation-id!))
+                                               context))])
+    (is (= "INTERCEPTOR_HTTP_TEST.1998.V2"
+           @test-state)))
+
+  (testing "Given a HTTP request, we should be able to receive a correlation-id header - Empty header"
+    (chain/execute {:request {:headers {}}}
+                   [common-traceability/with-correlation-id-http-interceptor
+                    (handler-fn->interceptor (fn [context]
+                                               (reset! test-state (common-traceability/current-correlation-id!))
+                                               context))])
+    (is (= "DEFAULT"
+           @test-state))))
+
+(s/deftest with-correlation-rabbitmq-interceptor-test
+  (testing "Given a incoming rabbitmq message, we should be able to receive a correlation-id from the metadata"
+    (chain/execute {:payload {:meta {:correlation-id "INTERCEPTOR_RABBITMQ_TEST.1998"}}}
+                   [common-traceability/with-correlation-id-rabbitmq-interceptor
+                    (handler-fn->interceptor (fn [context]
+                                               (reset! test-state (common-traceability/current-correlation-id!))
+                                               context))])
+    (is (= "INTERCEPTOR_RABBITMQ_TEST.1998"
+           @test-state)))
+
+  (testing "Given a incoming rabbitmq message, we should be able to receive a correlation-id from the metadata - No conflict with main thread"
+    (chain/execute {:payload {:meta {:correlation-id "INTERCEPTOR_RABBITMQ_TEST.1998.V2"}}}
+                   [common-traceability/with-correlation-id-rabbitmq-interceptor
+                    (handler-fn->interceptor (fn [context]
+                                               (reset! test-state (common-traceability/current-correlation-id!))
+                                               context))])
+    (is (= "INTERCEPTOR_RABBITMQ_TEST.1998.V2"
+           @test-state)))
+
+  (testing "Given a incoming rabbitmq message, we should be able to receive a correlation-id from the metadata - Empty metadata map"
+    (chain/execute {:payload {:meta {}}}
+                   [common-traceability/with-correlation-id-rabbitmq-interceptor
+                    (handler-fn->interceptor (fn [context]
+                                               (reset! test-state (common-traceability/current-correlation-id!))
+                                               context))])
+    (is (= "DEFAULT"
+           @test-state))))
+
+(s/deftest with-correlation-job-interceptor-test
+  (testing "Given a job execution, we should be able to identify logs from it using a job id"
+    (chain/execute {}
+                   [(common-traceability/with-correlation-id-job-interceptor "JOB_X.1998")
+                    (handler-fn->interceptor (fn [context]
+                                               (reset! test-state (common-traceability/current-correlation-id!))
+                                               context))])
+    (is (= "JOB_X.1998"
+           @test-state)))
+
+  (testing "Given a job execution, we should be able to identify logs from it using a job id - No conflict with main thread"
+    (chain/execute {}
+                   [(common-traceability/with-correlation-id-job-interceptor "JOB_Y.1998")
+                    (handler-fn->interceptor (fn [context]
+                                               (reset! test-state (common-traceability/current-correlation-id!))
+                                               context))])
+    (is (= "JOB_Y.1998"
+           @test-state))))


### PR DESCRIPTION
### Changed

- Refactored `common-clj.traceability.core` to be more flexible allowing more options to manipulate the
  `correlation-id`.