### PR TITLE
Fix the schema output expected for `common-clj.time.core/instant-now`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 45.0.1 - 2026-02-13
+
+### Fixed
+
+- Fix the schema output expected for `common-clj.time.core/instant-now`.
+
 ## 45.0.0 - 2026-02-13
 
 ### Changed/Added

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "45.0.0"
+(defproject net.clojars.macielti/common-clj "45.0.1"
 
   :description "Just common Clojure code that I use across projects"
 

--- a/src/common_clj/time/core.clj
+++ b/src/common_clj/time/core.clj
@@ -1,7 +1,7 @@
 (ns common-clj.time.core
   (:require [java-time.api :as jt]
             [schema.core :as s])
-  (:import (java.time LocalDate LocalDateTime ZoneOffset)
+  (:import (java.time Instant LocalDate LocalDateTime ZoneOffset)
            (java.util Date TimeZone)))
 
 (s/defn ^:deprecated local-datetime? :- s/Bool
@@ -29,6 +29,6 @@
   (-> (.toInstant value ZoneOffset/UTC)
       Date/from))
 
-(s/defn instant-now :- Date
+(s/defn instant-now :- Instant
   []
   (jt/instant))


### PR DESCRIPTION
### Fixed

- Fix the schema output expected for `common-clj.time.core/instant-now`.