### PR TITLE
Added function to convert from `java.util.Date` to `java.time.Instant`:   `common-clj.time.parser.core/legacy-date->instant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 45.1.1 - 2026-02-13
+
+### Added
+
+- Added function to convert from `java.util.Date` to `java.time.Instant`:
+  `common-clj.time.parser.core/legacy-date->instant`.
+
 ## 45.0.1 - 2026-02-13
 
 ### Fixed

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "45.0.1"
+(defproject net.clojars.macielti/common-clj "45.1.1"
 
   :description "Just common Clojure code that I use across projects"
 

--- a/src/common_clj/time/parser/core.clj
+++ b/src/common_clj/time/parser/core.clj
@@ -37,3 +37,7 @@
 (s/defn instant->legacy-date :- Date
   [instant :- Instant]
   (jt/java-date instant))
+
+(s/defn legacy-date->instant :- Instant
+  [legacy-date :- Date]
+  (.toInstant ^Date legacy-date))


### PR DESCRIPTION
### Added

- Added function to convert from `java.util.Date` to `java.time.Instant`:
  `common-clj.time.parser.core/legacy-date->instant`.
