### PR TITLE
Removed `danlentz/clj-uuid` dependency, due to incompatibility with graalvm native image generation process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 46.0.1 - 2026-02-14
+
+### Changed
+
+- Removed `danlentz/clj-uuid` dependency, due to incompatibility with graalvm native image generation process.
+
 ## 46.0.0 - 2026-02-14
 
 ### Changed

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "46.0.0"
+(defproject net.clojars.macielti/common-clj "46.0.1"
 
   :description "Just common Clojure code that I use across projects"
 
@@ -24,7 +24,6 @@
                  [integrant "1.0.1"]
                  [diehard "0.12.0"]
                  [org.clojure/tools.logging "1.3.1"]
-                 [danlentz/clj-uuid "0.2.5"]
                  [commons-io/commons-io "2.21.0"]]
 
   :profiles {:dev {:resource-paths ^:replace ["test/resources"]

--- a/src/common_clj/schema/extensions.clj
+++ b/src/common_clj/schema/extensions.clj
@@ -1,6 +1,5 @@
 (ns common-clj.schema.extensions
-  (:require [clj-uuid.core]
-            [schema.core :as s])
+  (:require [schema.core :as s])
   (:import (java.util.regex Pattern)))
 
 (s/defn custom-string-pattern
@@ -16,9 +15,14 @@
   (s/constrained s/Str #(or (re-matches #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6,9}$" %)
                             (re-matches #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$" %))))
 
+(def uuid-regex #"[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}")
+(defn uuid-string? [str]
+  (and (string? str)
+       (some? (re-matches uuid-regex str))))
+
 (s/defschema UuidWire
   "Example: '9c97de3b-ac65-44b2-ba4f-b65f8778e514'"
-  (s/constrained s/Str clj-uuid.core/uuid-string?))
+  (s/constrained s/Str uuid-string?))
 
 (s/defschema CalendarDateWire
   "Example: '2024-09-07'"


### PR DESCRIPTION
### Changed

- Removed `danlentz/clj-uuid` dependency, due to incompatibility with graalvm native image generation process.