### PR TITLE
Bump dev deps and release 46.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 46.1.3 - 2026-02-25
+
+### Changed
+
+- Bumped dev tooling dependencies: logback-classic 1.5.32, lein-clojure-lsp 2.0.14,
+  common-test-clj 7.0.2, service-component 7.4.4.
+
 ## 46.1.2 - 2026-02-25
 
 ### Added

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "46.1.2"
+(defproject net.clojars.macielti/common-clj "46.1.3"
 
   :description "Just common Clojure code that I use across projects"
 
@@ -31,13 +31,13 @@
                    :test-paths     ^:replace ["test/unit" "test/integration" "test/helpers"]
 
                    :plugins        [[lein-cloverage "1.2.4"]
-                                    [com.github.clojure-lsp/lein-clojure-lsp "2.0.13"]
+                                    [com.github.clojure-lsp/lein-clojure-lsp "2.0.14"]
                                     [com.github.liquidz/antq "RELEASE"]]
 
-                   :dependencies   [[net.clojars.macielti/common-test-clj "7.0.1"]
+                   :dependencies   [[net.clojars.macielti/common-test-clj "7.0.2"]
                                     [org.slf4j/slf4j-api "2.0.17"]
-                                    [ch.qos.logback/logback-classic "1.5.30"]
-                                    [net.clojars.macielti/service-component "7.4.3"]
+                                    [ch.qos.logback/logback-classic "1.5.32"]
+                                    [net.clojars.macielti/service-component "7.4.4"]
                                     [nubank/matcher-combinators "3.10.0"]
                                     [clj-http-fake "1.0.4"]
                                     [nubank/mockfn "0.7.0"]

--- a/src/common_clj/schema/extensions.clj
+++ b/src/common_clj/schema/extensions.clj
@@ -39,4 +39,3 @@
 (s/defschema NonNegativeInt
   "An integer greater than or equal to 0. Don't accept BigInt"
   (s/constrained s/Int #(or (= 0 %) (pos-int? %))))
-


### PR DESCRIPTION
### Changed

- Bumped dev tooling dependencies: logback-classic 1.5.32, lein-clojure-lsp 2.0.14,
  common-test-clj 7.0.2, service-component 7.4.4.