### PR TITLE
fix: loose-schema bug with nested schemas that are already loose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 46.1.5 - 2026-03-10
+
+### Fixed
+
+- Fixed bug in `loose-schema` function when handling nested schemas that are already loose.
+
 ## 46.1.4 - 2026-02-27
 
 ### Changed

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "46.1.4"
+(defproject net.clojars.macielti/common-clj "46.1.5"
 
   :description "Just common Clojure code that I use across projects"
 

--- a/src/common_clj/schema/core.clj
+++ b/src/common_clj/schema/core.clj
@@ -8,7 +8,9 @@
   "Takes a schema and converts it to a loose schema, so we can validate schemas that fulfils
   definition and accept more properties than defined initially."
   [schema]
-  (walk/postwalk #(if (map? %)
+  (walk/postwalk #(if (and (map? %)
+                           (not (record? %))
+                           (not (contains? % s/Keyword)))
                     (assoc % s/Keyword s/Any)
                     %)
                  schema))

--- a/test/unit/common_clj/schema/core_test.clj
+++ b/test/unit/common_clj/schema/core_test.clj
@@ -47,6 +47,49 @@
     (is (thrown? ExceptionInfo (s/validate (common-core-schema/loose-schema LooseSchemaExample) {:a "a"
                                                                                                  :c "c"})))))
 
+(def telegram
+  {:token                                  s/Str
+   (s/optional-key :poll-interval-seconds) s/Int
+   (s/optional-key :poll-timeout-seconds)  s/Int})
+
+(s/defschema Telegram
+  (common-core-schema/loose-schema telegram))
+
+(def config
+  {:telegram Telegram})
+
+(s/defschema Config
+  (common-core-schema/loose-schema config))
+
+(deftest loose-schema-with-nested-loose-schema-test
+
+  (testing "should validate a config with only required telegram fields"
+    (is (= {:telegram {:token "my-token"}}
+           (s/validate Config {:telegram {:token "my-token"}}))))
+
+  (testing "should validate a config with optional telegram fields"
+    (is (= {:telegram {:token                  "my-token"
+                       :poll-interval-seconds  10
+                       :poll-timeout-seconds   30}}
+           (s/validate Config {:telegram {:token                  "my-token"
+                                          :poll-interval-seconds  10
+                                          :poll-timeout-seconds   30}}))))
+
+  (testing "should accept extra keys in telegram (loose)"
+    (is (= {:telegram {:token     "my-token"
+                       :extra-key "extra-value"}}
+           (s/validate Config {:telegram {:token     "my-token"
+                                          :extra-key "extra-value"}}))))
+
+  (testing "should accept extra keys in config (loose)"
+    (is (= {:telegram  {:token "my-token"}
+            :extra-key "extra-value"}
+           (s/validate Config {:telegram  {:token "my-token"}
+                               :extra-key "extra-value"}))))
+
+  (testing "should reject config missing required telegram token"
+    (is (thrown? ExceptionInfo (s/validate Config {:telegram {}})))))
+
 (deftest un-namespaced-test
   (testing "GIVEN a namespaced schema WHEN I call un-namespaced on it THEN the schema should have only simple keywords"
     (is (= valid-map-for-un-namespaced-schema


### PR DESCRIPTION
## Summary

Fixed a bug in the `loose-schema` function where nested schemas that were already loose would cause a `More than one non-optional/required key schemata: [Keyword Keyword]` error.

## Root Cause

`clojure.walk/postwalk` treats schema record types (`Predicate`, `OptionalKey`, etc.) as maps since they implement `IPersistentMap`. This caused `{s/Keyword s/Any}` to be injected into schema type internals. When a schema value was itself already a loose schema (e.g., `Telegram` inside `Config`), the walk would add a duplicate `s/Keyword` entry.

## Fix

Added two guards to the `postwalk` predicate:
- `(not (record? %))` — skips schema record types like `Predicate`, `OptionalKey`
- `(not (contains? % s/Keyword))` — skips maps that already have a `s/Keyword` catch-all key

## Changes

- **`src/common_clj/schema/core.clj`**: Fixed `loose-schema` function
- **`test/unit/common_clj/schema/core_test.clj`**: Added `loose-schema-with-nested-loose-schema-test` with 5 test cases
- **`project.clj`**: Version bump to `46.1.5`
- **`CHANGELOG.md`**: Added entry for `46.1.5`