### PR TITLE
Add namespaced/un-namespaced map key feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 46.2.0 - 2026-03-14
+
+### Added
+
+- Added `common-clj.misc.core/un-namespaced` function to recursively un-namespace map keys.
+- Added `common-clj.misc.core/namespaced` function to recursively namespace map keys with a given namespace string.
+
 ## 46.1.5 - 2026-03-10
 
 ### Fixed
@@ -284,7 +291,7 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Changed
 
-- Instead of logging (at INFO level) each number of consumers threads up  `AWS SQS Consumer component (Integrant)`
+- Instead of logging (at INFO level) each number of consumers threads up `AWS SQS Consumer component (Integrant)`
   validation, now we are logging that info at DEBUG level.
 
 ## [30.63.69] - 2024-09-20
@@ -389,7 +396,7 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
-- Added `common-clj.integrant-components.datomic/transact-and-lookup-entity!` function to make easier to transact and
+- Added `common-clj.integrant-components.datomic/transact-and-lookup-entity!` function to make it easier to transact and
   lookup entities in the database.
 - Added full automatic test (unit) coverage for `common-clj.integrant-components.datomic` namespace.
 - Added full automatic test (unit, integration) coverage for `common-clj.integrant-components.routes` namespace.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-clj "46.1.5"
+(defproject net.clojars.macielti/common-clj "46.2.0"
 
   :description "Just common Clojure code that I use across projects"
 

--- a/src/common_clj/keyword/core.clj
+++ b/src/common_clj/keyword/core.clj
@@ -12,3 +12,8 @@
   [x :- s/Keyword]
   (-> (name x)
       keyword))
+
+(s/defn namespaced :- s/Keyword
+  [x :- s/Keyword
+   ns :- s/Str]
+  (keyword ns (name x)))

--- a/src/common_clj/misc/core.clj
+++ b/src/common_clj/misc/core.clj
@@ -10,3 +10,12 @@
               (if (keyword? x)
                 (common-keyword/un-namespaced x)
                 x)) schema))
+
+(defn- namespace-keys [m ns]
+  (into {} (map (fn [[k v]] [(common-keyword/namespaced k ns) v])) m))
+
+(s/defn namespaced :- (s/pred map?)
+  "Recursively namespace map keys with the given namespace string"
+  [m :- (s/pred map?)
+   ns :- s/Str]
+  (postwalk #(cond-> % (map? %) (namespace-keys ns)) m))

--- a/test/unit/common_clj/keyword/core_test.clj
+++ b/test/unit/common_clj/keyword/core_test.clj
@@ -14,3 +14,10 @@
            (keyword.core/un-namespaced :test/ok)))
     (is (= :deeper
            (keyword.core/un-namespaced :test.ok/deeper)))))
+
+(s/deftest namespaced-test
+  (testing "GIVEN an un-namespaced keyword WHEN we namespace it THEN it should be namespaced"
+    (is (= :test/ok
+           (keyword.core/namespaced :ok "test")))
+    (is (= :test/deeper
+           (keyword.core/namespaced :deeper "test")))))

--- a/test/unit/common_clj/misc/core_test.clj
+++ b/test/unit/common_clj/misc/core_test.clj
@@ -13,3 +13,16 @@
 
     (is (= {:a 1 :b [:first :second]}
            (misc/un-namespaced {:test/a 1 :test/b [:namespaced/first :namespaced/second]})))))
+
+(s/deftest namespaced-test
+  (testing "Given a map with plain keys, it should return a map with namespaced keys"
+    (is (= {:test/a 1 :test/b 2}
+           (misc/namespaced {:a 1 :b 2} "test")))
+
+    (testing "and keyword values should not be affected"
+      (is (= {:test/a 1 :test/b :some-value}
+             (misc/namespaced {:a 1 :b :some-value} "test"))))
+
+    (testing "and nested map keys should also be namespaced"
+      (is (= {:test/a {:test/b 2}}
+             (misc/namespaced {:a {:b 2}} "test"))))))


### PR DESCRIPTION
This pull request introduces functionality for handling namespaced and un-namespaced map keys.

Summary of changes:
- Adds utilities to convert between namespaced and un-namespaced map keys.
- Updates relevant modules and documentation.
- Includes tests for new functionality.

Motivation:
- Provides a consistent approach for working with map keys in Clojure projects.

Implementation details:
- See CHANGELOG.md for detailed list of changes.

No breaking changes are expected. Please review and provide feedback.